### PR TITLE
Add support for packer builds of Vagrant boxes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /mod-circulation-src
 /mod-users-src
 /raml-module-builder
+/packer/.vagrant
+/packer/*.ov*
+*.box
+

--- a/folio.yml
+++ b/folio.yml
@@ -18,7 +18,12 @@
 # Provision a host as a Stripes server
 - hosts: stripes
   roles:
-    - stripes-docker 
+    - stripes-docker
+
+# Roles for building Vagrant boxes
+- hosts: vagrant
+  roles:
+    - vagrant-tidy
 
 # Provision a host to support FOLIO Developer Curriculum
 - hosts: build_curriculum

--- a/packer/Vagrantfile
+++ b/packer/Vagrantfile
@@ -1,0 +1,10 @@
+# Vagrantfile to build a VM to serve as the base box
+Vagrant.configure("2") do |config|
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 4096
+    vb.cpus = 2
+  end
+  config.vm.box = "debian/jessie64"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.ssh.insert_key = false
+end

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -1,0 +1,59 @@
+{
+  "_comments": [
+    "Builds depend on ova file built from debian/jessie64 image; see Vagrantfile for details"
+  ],
+  "builders": [
+    {
+      "name": "stable",
+      "type": "virtualbox-ovf",
+      "headless": true,
+      "source_path": "packer/debian_jessie64-8.8.1.ova",
+      "checksum": "009de373c05a50c9dc308c04a76703e0",
+      "checksum_type": "md5",
+      "ssh_username": "vagrant",
+      "ssh_private_key_file": "packer/vagrant_key.txt",
+      "shutdown_command": "echo 'packer' | sudo -S shutdown -P now"
+    },
+    {
+      "name": "testing",
+      "type": "virtualbox-ovf",
+      "headless": true,
+      "source_path": "packer/debian_jessie64-8.8.1.ova",
+      "checksum": "009de373c05a50c9dc308c04a76703e0",
+      "checksum_type": "md5",
+      "ssh_username": "vagrant",
+      "ssh_private_key_file": "packer/vagrant_key.txt",
+      "shutdown_command": "echo 'packer' | sudo -S shutdown -P now"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "ansible",
+      "playbook_file": "./folio.yml",
+      "groups": [
+        "stable",
+        "vagrant",
+        "folio-backend",
+        "stripes"
+      ],
+      "only": ["stable"]
+    },
+    {
+      "type": "ansible",
+      "playbook_file": "./folio.yml",
+      "groups": [
+        "testing",
+        "vagrant",
+        "folio-backend",
+        "stripes"
+      ],
+      "only": ["testing"]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "vagrantfile_template": "Vagrantfile.demo"
+    }
+  ]
+}

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -53,7 +53,3 @@
     filename: folioci
     state: present
   with_items: "{{ folio_apt_repos }}"
-
-- name: Copy vagrant-tidy.sh to /root
-  become: yes
-  copy: src=vagrant-tidy.sh dest=/root/vagrant-tidy.sh mode=0700

--- a/roles/vagrant-tidy/files/vagrant-tidy.sh
+++ b/roles/vagrant-tidy/files/vagrant-tidy.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-cat - << EOWARNING
-WARNING: This script will fill up your left over disk space.
+# cat - << EOWARNING
+# WARNING: This script will fill up your left over disk space.
 
-DO NOT RUN THIS WHEN YOUR VIRTUAL HD IS RAW!!!!!!
+# DO NOT RUN THIS WHEN YOUR VIRTUAL HD IS RAW!!!!!!
 
-You should NOT do this on a running system.
-This is purely for making vagrant boxes damn small.
+# You should NOT do this on a running system.
+# This is purely for making vagrant boxes damn small.
 
-Press Ctrl+C within the next 10 seconds if you want to abort!!
+# Press Ctrl+C within the next 10 seconds if you want to abort!!
 
-EOWARNING
-sleep 10;
+# EOWARNING
+# sleep 10;
 
 # Remove APT cache
 apt-get clean -y

--- a/roles/vagrant-tidy/tasks/main.yml
+++ b/roles/vagrant-tidy/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# Role to tidy up a Vagrant box for packaging
+# Note that vagrant-tidy.sh destroys all free disk space!
+- name: Copy vagrant-tidy.sh to /root
+  become: yes
+  copy: src=vagrant-tidy.sh dest=/root/vagrant-tidy.sh mode=0700
+
+- name: Stop services
+  become: yes
+  service: name={{ item }} state=stopped
+  with_items:
+    - okapi-deploy
+    - okapi
+    - docker
+    - postgresql
+
+- name: Run vagrant-tidy.sh
+  become: yes
+  command: /root/vagrant-tidy.sh


### PR DESCRIPTION
Towards FOLIO-383. Add Vagrantfile for creating base box OVA, packer template for building "stable" and "testing". Move "vagrant-tidy" into its own role to be executed for hosts in the "vagrant" group.