### PR TITLE
add login information

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ create a new directory, `cd` into it, and try:
     $ vagrant init folio/stable
     $ vagrant up
 
+Now you can open [http://localhost:3000](http://localhost:3000).
+Admin login: diku\_admin/admin
+
 Or, if you want to try a prepackaged FOLIO backend Vagrant box, try:
 
     $ vagrant init folio/stable-backend


### PR DESCRIPTION
If we don't want the credentials here insert "Admin login: see [Vagrant folio/stable](https://app.vagrantup.com/folio/boxes/stable)".