### PR TITLE
Invoke yarn without --

### DIFF
--- a/roles/stripes-docker/files/build-run
+++ b/roles/stripes-docker/files/build-run
@@ -1,5 +1,5 @@
 cd /etc/folio/stripes/
-sudo yarn build output
+sudo yarn build output --sourcemap
 docker stop stripes_stripes_1
 docker rm stripes_stripes_1
 docker rmi stripes

--- a/roles/stripes-docker/files/build-run
+++ b/roles/stripes-docker/files/build-run
@@ -1,5 +1,5 @@
 cd /etc/folio/stripes/
-sudo yarn build -- output
+sudo yarn build output
 docker stop stripes_stripes_1
 docker rm stripes_stripes_1
 docker rmi stripes


### PR DESCRIPTION
-- is deprecated. Yarn says:

    warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.