### PR TITLE
Fix troubleshooting note about metadata_url

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -34,7 +34,7 @@ used to generate prebuilt Vagrant boxes, available on
 
 * [folio/stable-backend](https://app.vagrantup.com/folio/boxes/stable-backend)
   -- a backend FOLIO system with stable releases of backend modules. All
-  components should interoperate correctly. 
+  components should interoperate correctly.
 
 * [folio/snapshot](https://app.vagrantup.com/folio/boxes/snapshot)
   -- a full-stack FOLIO system, built from the most recent working
@@ -212,15 +212,19 @@ The Vagrantfile in this project contains six target definitions:
 As of 5 Feb 2018: If you have an existing Vagrant VM based on a
 Vagrant box file created before this date, you may have an issue with
 the metadata URL for the box file. Check the file
-`~/.vagrant.d/boxes/<box ID>/metadata_url`. If it has an address of the
-form `https://atlas.hashicorp.com/[...]` replace `atlas.hashicorp`
-with `vagrantcloud`. If you are using a version of Vagrant \<= 1.9.6,
-upgrade Vagrant to prevent future problems initializing Vagrant VMs.
+`cat ~/.vagrant.d/boxes/<box ID>/metadata_url`. If it has an address of the
+form `https://atlas.hashicorp.com/[...]` then the `atlas.hashicorp`
+needs to be replaced with `vagrantcloud`.
+
+Note: Do not use a text-editor, as they are not proper text files.
 
 To replace the metadata URL for all the boxes in your `~/.vagrant.d`
-directory, use the following `sed` script:
+directory, use the following `Perl one-liner` script:
 
-    sed -i -- 's/atlas.hashicorp/vagrantcloud/g' ~/.vagrant.d/boxes/*/metadata_url
+    perl -p -i -e 's/atlas.hashicorp/vagrantcloud/' ~/.vagrant.d/boxes/*/metadata_url
+
+If you are using a version of Vagrant \<= 1.9.6,
+upgrade Vagrant to prevent future problems initializing Vagrant VMs.
 
 For more information, see https://github.com/hashicorp/vagrant/issues/9442
 


### PR DESCRIPTION
Use a Perl one-liner rather than sed

The previous fix using 'sed' causes another issue. These vagrant files are not really text files because they are missing the end-of-line for this single-line file. The sed on macOS does add the EOL. Then 'vagrant up' gives a warning about "Illegal characters found in URL" and 'vagrant box update' treats that as an error. So use this Perl one-liner instead.