### PR TITLE
Add mechanism to pin a module to a particular build for the snapshot builds.

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -26,6 +26,10 @@ mod_circulation_prefixes:
 inv_storage_3: true
 enable_okapi: true
 
+# Pinned modules
+pinned_modules:
+  - { module: mod-permissions, version: 5.0.1-SNAPSHOT.11 }
+
 # dockerCMD values for modules
 docker_cmd:
   mod-login:

--- a/roles/okapi-deploy-config/defaults/main.yml
+++ b/roles/okapi-deploy-config/defaults/main.yml
@@ -8,6 +8,8 @@ pg_admin_password: folio_admin
 pg_host: "{{ ansible_default_ipv4.address }}"
 pg_port: 5432
 module_database: okapi_modules
+# pinned modules
+pinned_modules: []
 # default dockerCMD values for modules
 docker_cmd: {}
 # default env values for modules

--- a/roles/okapi-deploy-config/tasks/main.yml
+++ b/roles/okapi-deploy-config/tasks/main.yml
@@ -27,13 +27,32 @@
     body: "{{ module_list }}"
   register: module_deps
 
-- name: Init modules deploy list
-  set_fact: deploy_mods=[]
+- name: Build module_deps_list, remove modules that are pinned
+  set_fact:
+    module_deps_list: "{{ module_deps_list|default([]) }} + [{{ item.0 }}]"
+  when: item[0].id|regex_search(item[1].module) != item[1].module
+  with_nested:
+    - "{{ module_deps.json }}"
+    - "{{ pinned_modules }}"
+
+- name: Set module_deps_list if empty
+  set_fact:
+    module_deps_list: "{{ module_deps.json }}"
+  when: module_deps_list is not defined
+
+- name: Build pinned_modules_list
+  set_fact:
+    pinned_modules_list: "{{ pinned_modules_list|default([]) + [ { 'id': item.module + '-' + item.version, 'action': 'enable' } ] }}"
+  with_items: "{{ pinned_modules }}"
+
+- name: Combine lists
+  set_fact:
+    module_deps_list: "{{ module_deps_list|union(pinned_modules_list|default([]))|unique }}"
 
 - name: Build module deploy list
-  set_fact: deploy_mods="{{ deploy_mods }} + ['{{ item.id }}']"
+  set_fact: deploy_mods="{{ deploy_mods|default([]) }} + ['{{ item.id }}']"
   when: item.id|regex_search('^mod-')
-  with_items: "{{ module_deps.json }}"
+  with_items: "{{ module_deps_list }}"
 
 - name: Pull Docker images
   become: yes
@@ -69,7 +88,7 @@
 
 - name: Build module enable list
   set_fact: enable_mods="{{ enable_mods }} + ['{{ item.id }}']"
-  with_items: "{{ module_deps.json }}"
+  with_items: "{{ module_deps_list }}"
 
 - name: Find mod-permissions in list
   set_fact: mod_perms_id="{{ enable_mods|join(',')|regex_search('(mod-permissions-\d+\.\d+\.\d+[a-zA-Z0-9\.-]*)') }}"


### PR DESCRIPTION
Pin mod-permissions to v5.0.1-SNAPSHOT.11. Temporary workaround for FOLIO-1153.