### PR TITLE
Remove mod-auth-data dependency for tenant-admin-permissions.

### DIFF
--- a/roles/tenant-admin-permissions/meta/main.yml
+++ b/roles/tenant-admin-permissions/meta/main.yml
@@ -1,5 +1,4 @@
 ---
 dependencies:
   - { role: tenant-data }
-  - { role: mod-auth-data }
 

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-
+# Note: admin user must be bootstrapped and have mod-permissions perms
 - name: get list of tenant modules
   uri: 
     url: "{{ okapi_url }}/_/proxy/tenants/{{ tenant }}/modules"


### PR DESCRIPTION
Breaks stripes-testing CI build. Towards FOLIO-1153.