### PR TITLE
add top_down_install condition to permissions tasks

### DIFF
--- a/roles/mod-circulation-data/tasks/main.yml
+++ b/roles/mod-circulation-data/tasks/main.yml
@@ -31,7 +31,7 @@
   register: admin_perms
   changed_when: admin_perms.status == 200
   with_items: "{{ circulation_admin_permissions }}"
-  when: auth_required and auth_by_username
+  when: auth_required and auth_by_username and not top_down_install
 
 - name: Grant additional permissions to {{ admin_user.username }} (auth by id)
   uri:
@@ -47,7 +47,7 @@
   register: admin_perms
   changed_when: admin_perms.status == 200
   with_items: "{{ circulation_admin_permissions }}"
-  when: auth_required and not auth_by_username
+  when: auth_required and not auth_by_username and not top_down_install
 
 - name: Load loan policies
   uri:

--- a/roles/mod-inventory-data/tasks/main.yml
+++ b/roles/mod-inventory-data/tasks/main.yml
@@ -31,7 +31,7 @@
   register: admin_perms
   changed_when: admin_perms.status == 200
   with_items: "{{ inventory_admin_permissions }}"
-  when: auth_required and auth_by_username
+  when: auth_required and auth_by_username and not top_down_install
 
 - name: Grant additional permissions to {{ admin_user.username }} (auth by id)
   uri:
@@ -47,7 +47,7 @@
   register: admin_perms
   changed_when: admin_perms.status == 200
   with_items: "{{ inventory_admin_permissions }}"
-  when: auth_required and not auth_by_username
+  when: auth_required and not auth_by_username and not top_down_install
 
 - name: Check for sample instances
   uri:


### PR DESCRIPTION
add 'top_down_install' conditional check to mod circulation-data and mod-inventory-data tasks that load module permissions for admin user