### PR TITLE
tenant agnostic mod-auth-demo-users.   remove dependency on mod-auth-data

### DIFF
--- a/roles/mod-auth-demo-users/defaults/main.yml
+++ b/roles/mod-auth-demo-users/defaults/main.yml
@@ -2,3 +2,7 @@
 # Record key for mod-users total records, default "total_records"
 total_records_key: total_records
 auth_by_username: false
+tenant: diku
+admin_user:
+  username: diku_admin
+  password: admin

--- a/roles/mod-auth-demo-users/meta/main.yml
+++ b/roles/mod-auth-demo-users/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - mod-auth-data

--- a/roles/mod-auth-demo-users/tasks/main.yml
+++ b/roles/mod-auth-demo-users/tasks/main.yml
@@ -9,20 +9,20 @@
     method: POST
     body_format: json
     headers:
-      X-Okapi-Tenant: diku
+      X-Okapi-Tenant: "{{ tenant }}"
       Accept: application/json
     body: "{ 'username' : '{{ admin_user.username }}', 'password' : '{{ admin_user.password }}' }"
     status_code: 201
-  register: mod_auth_login
+  register: tenant_admin_login
 
 # Get users up to 300
 - name: Get 1st 100 users
   uri:
     url: "{{ okapi_url }}/users?limit=100"
     headers:
-      X-Okapi-Tenant: diku
+      X-Okapi-Tenant: "{{ tenant }}"
       Accept: application/json
-      X-Okapi-Token: "{{ mod_auth_login.x_okapi_token | default('token') }}"
+      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token | default('token') }}"
   register: users1
 
 - name: Copy users to variable
@@ -32,9 +32,9 @@
   uri:
     url: "{{ okapi_url }}/users?offset=100&limit=100"
     headers:
-      X-Okapi-Tenant: diku
+      X-Okapi-Tenant: "{{ tenant }}"
       Accept: application/json
-      X-Okapi-Token: "{{ mod_auth_login.x_okapi_token | default('token') }}"
+      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token | default('token') }}"
   register: users2
   when: users1.json.{{ total_records_key }} > 100
 
@@ -46,9 +46,9 @@
   uri:
     url: "{{ okapi_url }}/users?offset=200&limit=100"
     headers:
-      X-Okapi-Tenant: diku
+      X-Okapi-Tenant: "{{ tenant }}"
       Accept: application/json
-      X-Okapi-Token: "{{ mod_auth_login.x_okapi_token | default('token') }}"
+      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token | default('token') }}"
   register: users3
   when: users1.json.{{ total_records_key }} > 200
 
@@ -62,8 +62,8 @@
     method: POST
     body_format: json
     headers:
-      X-Okapi-Tenant: diku
-      X-Okapi-Token: "{{ mod_auth_login.x_okapi_token }}"
+      X-Okapi-Tenant: "{{ tenant }}"
+      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token }}"
       Accept: application/json
     body: '{ "username" : "{{ item.username }}", "password" : "{{ item.username }}" }'
     status_code: 201,422
@@ -77,8 +77,8 @@
     method: POST
     body_format: json
     headers:
-      X-Okapi-Tenant: diku
-      X-Okapi-Token: "{{ mod_auth_login.x_okapi_token }}"
+      X-Okapi-Tenant: "{{ tenant }}"
+      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token }}"
       Accept: application/json
     body: '{ "username" : "{{ item.username }}" }'
     status_code: 201,422
@@ -93,8 +93,8 @@
     method: POST
     body_format: json
     headers:
-      X-Okapi-Tenant: diku
-      X-Okapi-Token: "{{ mod_auth_login.x_okapi_token }}"
+      X-Okapi-Tenant: "{{ tenant }}"
+      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token }}"
       Accept: application/json
     body: '{ "userId" : "{{ item.id }}" }'
     status_code: 201,422


### PR DESCRIPTION
- mod-auth-demo-users now has a configurable 'tenant' with a default value of 'diku'
- remove mod-auth-data dependency from mod-auth-demo-users so that the role can be used without mod-auth-data (CI).  
