### PR TITLE
Allow Okapi version to be specified in `okapi` role.

### DIFF
--- a/roles/okapi/defaults/main.yml
+++ b/roles/okapi/defaults/main.yml
@@ -1,4 +1,6 @@
-
+---
+# add a version for the package, e.g. "2.17.0-1"
+okapi_version:
 okapi_role: cluster
 # 'eth0' is the default ec2 network interface. May be different on other systems
 okapi_interface: eth0

--- a/roles/okapi/tasks/main.yml
+++ b/roles/okapi/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: Install okapi debian package 
   become: yes
   apt: 
-    name: okapi 
+    name: "okapi{% if okapi_version %}={{ okapi_version }}{% endif %}"
     state: present
 
 - name: Enable external hazelcast config if AWS


### PR DESCRIPTION
Allows pinning of Okapi version for repeatable builds. Resolves FOLIO-833.