### PR TITLE
Build webpack early in testing build.

### DIFF
--- a/folio.yml
+++ b/folio.yml
@@ -14,9 +14,13 @@
     - okapi-deploy-modules
     - enable-tenant-modules
 
+# Need to build the webpack early to allow enough RAM for the build
+# But don't want to enable modules at this point
 - name: Configure testing build
   hosts: testing
   roles:
+    - role: stripes-build
+      okapi_enable_modules: false
     - okapi-deploy-modules
     - enable-tenant-modules
     - create-tenant-admin


### PR DESCRIPTION
Building the webpack requires significant RAM, so it's better to do it before the full backend is deployed. Fixes FOLIO-1514.