### PR TITLE
Make vagrant-tidy role more tolerant of failure.

### DIFF
--- a/roles/vagrant-tidy/tasks/main.yml
+++ b/roles/vagrant-tidy/tasks/main.yml
@@ -13,11 +13,12 @@
     - okapi
     - docker
     - postgresql
+  ignore_errors: yes
 
 # packer sticks this in here?
 - name: Remove guest additions ISO, if there
   become: yes
-  command: rm -rf /vagrant/VBoxGuestAdditions.iso
+  command: rm -rf /home/vagrant/VBoxGuestAdditions.iso
 
 - name: Run vagrant-tidy.sh
   become: yes


### PR DESCRIPTION
Not all services may exist, so we shouldn't fail if we can't stop them.