### PR TITLE
Update Okapi package version for Q3-2018 release.

### DIFF
--- a/group_vars/release
+++ b/group_vars/release
@@ -6,6 +6,7 @@ enable_okapi: true
 deploy_url: https://rawgit.com/folio-org/platform-complete/q3-2018/okapi-install.json
 enable_url: https://rawgit.com/folio-org/platform-complete/q3-2018/stripes-install.json
 update_launch_descr: true
+okapi_version: 2.17.4-2
 
 # module settings
 folio_modules:


### PR DESCRIPTION
Update version to Okapi 2.17.4-2, with updated systemd configuration. Towards FOLIO-1542.