### PR TITLE
Add environment variables to snapshot configuration

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -78,8 +78,10 @@ env_var:
     - { name: JAVA_OPTIONS, value: "-Xmx256m" }
   mod-source-record-storage:
     - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    - { name: "test.mode", value: "true" }
   mod-source-record-manager:
     - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    - { name: "test.mode", value: "true" }
   mod-data-import:
     - { name: JAVA_OPTIONS, value: "-Xmx256m" }
   mod-gobi:


### PR DESCRIPTION
For mod-source-record-storage and mod-source-record-manager.

Set `testing.mode=true`. FOLIO-1616.