### PR TITLE
Create ansible build profiles for core modules only

### DIFF
--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -1,0 +1,77 @@
+---
+# Variables for building testing-topdown
+okapi_pull: true
+okapi_pull_timeout: 600
+top_down_install: true
+auth_required: true
+total_records_key: totalRecords
+load_addresstypes: true
+inv_storage_3: true
+load_mods_larger: true
+hierarchical_locations: true
+shelf_locations: false
+enable_okapi: true
+
+# set the default postgres connection pool per module/tenant
+pg_max_pool_size: 5
+
+# dockerCMD values for modules
+docker_cmd:
+  mod-login:
+    - "verify.user=true"
+
+# env values for modules
+env_var:
+  mod-authtoken:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-permissions:
+    - { name: JAVA_OPTIONS, value: "-Xmx512m" }
+  mod-login:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-configuration:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-users:
+    - { name: JAVA_OPTIONS, value: "-Xmx384m" }
+  mod-users-bl:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-login-saml:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-inventory-storage:
+    - { name: JAVA_OPTIONS, value: "-Xmx512m" }
+  mod-inventory:
+    - { name: JAVA_OPTIONS, value: "-Dorg.folio.metadata.inventory.storage.type=okapi" }
+  mod-circulation-storage:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-circulation:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-notify:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-notes:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-codex-inventory:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-codex-mux:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-password-validator:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+
+# other modules to enable outside dependency resolution
+other_mods:
+  - mod-codex-inventory
+
+# Docker ports for modules
+docker_port:
+  mod-inventory: 9403
+  mod-circulation: 9801
+
+# Variables for building UI
+stripes_github_project: https://github.com/folio-org/platform-core
+stripes_github_version: snapshot
+folio_npm_repo: npm-folioci
+stripes_strict_md: true
+platform_remove_lock: false
+# mod descrs are built by `yarn install` in folio-testing-platform
+# build_module_descriptors: false
+
+# Metadata for CI build
+version: 1.0.0

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -1,0 +1,125 @@
+---
+# Variables for building testing/testing-backend
+auth_required: true
+total_records_key: totalRecords
+load_addresstypes: true
+inv_storage_3: true
+hierarchical_locations: true
+load_mods_larger: true
+shelf_locations: false
+enable_okapi: true
+
+# used in okapi-tenant-deploy
+update_launch_descr: true
+
+# set the default postgres connection pool per module/tenant
+pg_max_pool_size: 5
+
+folio_modules:
+  - name: mod-authtoken
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-permissions
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx512m" }
+    deploy: yes
+
+  - name: mod-login
+    docker_cmd:
+      - "verify.user=true"
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-configuration
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-users
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx384m" }
+    deploy: yes
+
+  - name: mod-inventory-storage
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx512m" }
+    deploy: yes
+
+  - name: mod-password-validator
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-users-bl
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-login-saml
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-inventory
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Dorg.folio.metadata.inventory.storage.type=okapi" }
+    deploy: yes
+
+  - name: mod-circulation-storage
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-circulation
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-notify
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-notes
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-codex-inventory
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-codex-mux
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-feesfines
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+  - name: mod-tags
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
+
+# Variables for building UI
+stripes_github_project: https://github.com/folio-org/platform-core
+stripes_github_version: snapshot
+folio_npm_repo: npm-folioci
+platform_remove_lock: false
+# mod descrs are built by `yarn install` in folio-testing-platform
+# build_module_descriptors: false
+okapi_register_modules: true
+okapi_enable_modules: true
+node_environment:
+  NODE_ENV:
+
+# Metadata for CI build
+version: 5.0.0


### PR DESCRIPTION
Created group vars for snapshot-core (folio-snapshot) and testing-core (folio-testing) consisting of core modules only (from 'platform-core).  