### PR TITLE
Add new inventory reference data to testing/snapshot builds.

### DIFF
--- a/folio.yml
+++ b/folio.yml
@@ -64,11 +64,13 @@
       repository: "https://github.com/folio-org/mod-inventory-storage"
       duplicate_key_error: 400
       files:
+        - { load_endpoint: /alternative-title-types, fileglob: reference-data/alternative-title-types/*.json }
         - { load_endpoint: /call-number-types, fileglob: reference-data/call-number-types/*.json }
         - { load_endpoint: /classification-types, fileglob: reference-data/classification-types/*.json }
         - { load_endpoint: /contributor-name-types, fileglob: reference-data/contributor-name-types/*.json }
         - { load_endpoint: /contributor-types, fileglob: reference-data/contributor-types/*.json }
         - { load_endpoint: /electronic-access-relationships, fileglob: reference-data/electronic-access-relationships/*.json }
+        - { load_endpoint: /holdings-note-types, fileglob: reference-data/holdings-note-types/*.json }
         - { load_endpoint: /holdings-types, fileglob: reference-data/holdings-types/*.json }
         - { load_endpoint: /identifier-types, fileglob: reference-data/identifier-types/*.json }
         - { load_endpoint: /ill-policies, fileglob: reference-data/ill-policies/*.json }
@@ -76,6 +78,7 @@
         - { load_endpoint: /instance-relationship-types, fileglob: reference-data/instance-relationship-types/*.json }
         - { load_endpoint: /instance-statuses, fileglob: reference-data/instance-statuses/*.json }
         - { load_endpoint: /instance-types, fileglob: reference-data/instance-types/*.json }
+        - { load_endpoint: /item-note-types, fileglob: reference-data/item-note-types/*.json }
         - { load_endpoint: /loan-types, fileglob: reference-data/loan-types/*.json }
         - { load_endpoint: /location-units/institutions, fileglob: reference-data/location-units/institutions/*.json, dup_override: 422 }
         - { load_endpoint: /location-units/campuses, fileglob: reference-data/location-units/campuses/*.json, dup_override: 422 }
@@ -85,7 +88,8 @@
         - { load_endpoint: /modes-of-issuance, fileglob: reference-data/modes-of-issuance/*.json }
         - { load_endpoint: /platforms, fileglob: reference-data/platforms/*.json }
         - { load_endpoint: /service-points, fileglob: reference-data/service-points/*.json, dup_override: 422 }
-        - { load_endpoint: /statistical-code-types, fileglob: reference-data/statistical-code-types/*.json }
+        - { load_endpoint: /statistical-code-types, fileglob: reference-data/statistical-code-types/*.json, dup_override: 422 }
+        - { load_endpoint: /statistical-codes, fileglob: reference-data/statistical-codes/*.json }
         - { load_endpoint: /instance-storage/instances, fileglob: sample-data/instances/*.json }
         - { load_endpoint: /instance-storage/instances/$filename/source-record/marc-json, fileglob: sample-data/instance-source-records/*.json, http_method: PUT, dup_override: 204, updated_code: 204 }
         - { load_endpoint: /holdings-storage/holdings, fileglob: sample-data/holdingsrecords/*.json }


### PR DESCRIPTION
* alternative-title-types
* holdings-note-types
* item-note-types
* statistical-codes

Also correct dup key override for statistical-code-types. Towards FOLIO-1634.