### PR TITLE
add mod-calendar to core platforms.  enable prior to circulation modules

### DIFF
--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -36,6 +36,8 @@ env_var:
     - { name: JAVA_OPTIONS, value: "-Xmx256m" }
   mod-login-saml:
     - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+  mod-calendar:
+    - { name: JAVA_OPTIONS, value: "-Xmx256m" }
   mod-inventory-storage:
     - { name: JAVA_OPTIONS, value: "-Xmx512m" }
   mod-inventory:

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -73,6 +73,11 @@ folio_modules:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
     deploy: yes
 
+  - name: mod-calendar
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
   - name: mod-inventory
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Dorg.folio.metadata.inventory.storage.type=okapi" }
@@ -119,11 +124,6 @@ folio_modules:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
     deploy: yes
 
-  - name: mod-calendar
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    deploy: yes
-    
   - name: mod-finance-storage
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -68,6 +68,11 @@ folio_modules:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
     deploy: yes
 
+  - name: mod-calendar
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    deploy: yes
+
   - name: mod-inventory
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Dorg.folio.metadata.inventory.storage.type=okapi" }


### PR DESCRIPTION
FOLIO-1674:

- Add mod-calendar to 'snapshot-core' due to upcoming dependency change to circ modules.
- Enable mod-calendar before circ modules due to upcoming dependency change in 'testing' and 'testing-core'
