### PR TITLE
FOLIO-1892 disable default nginx vhost

### DIFF
--- a/roles/edge-nginx/tasks/main.yml
+++ b/roles/edge-nginx/tasks/main.yml
@@ -10,6 +10,12 @@
   service: name=nginx state=started
   ignore_errors: yes
 
+- name: disable nginx default vhost
+  become: yes
+  file: path=/etc/nginx/sites-enabled/default
+  state: absent
+  notify: Restart nginx
+
 - name: Install edge module configuration for nginx
   become: yes
   template: src=edge.conf.j2 dest=/etc/nginx/sites-available/edge force=no


### PR DESCRIPTION
The default vhost that binds to port 80 needs to be disabled so that the docker container running stripes can bind to port 80. 