### PR TITLE
Remove support for Jessie from documentation and openjdk-8 role.

### DIFF
--- a/doc/ansible-roles.md
+++ b/doc/ansible-roles.md
@@ -2,7 +2,7 @@
 
 The [main playbook](../folio.yml) and [Vagrantfile](../Vagrantfile) in
 this repository are targeted to build FOLIO systems using Ansible
-against a Debian Jessie or Ubuntu Xenial host. The Ansible inventory
+against an Ubuntu 16.04 (Xenial) host. The Ansible inventory
 is designed to support a few groups as follows:
 
 * `folio` -- targets hosts for building a full FOLIO system
@@ -17,7 +17,7 @@ settings for the `vagrant`, and `testing` groups.
 
 The folio.yml playbook uses the following roles:
 
-*All roles targeted for Debian 8 (Jessie)/Ubuntu Xenial*
+*All roles targeted for Ubuntu 16.04 (Xenial)*
 
 ## ansible
 Installs Ansible from the Ansible repository

--- a/roles/openjdk-8/tasks/main.yml
+++ b/roles/openjdk-8/tasks/main.yml
@@ -1,26 +1,14 @@
 ---
-# Install openjdk-8-jdk 
+# Install openjdk-8-jdk
 - name: Install python-apt
   become: yes
   apt: name=python-apt state=present
 
-- name: Add backports apt repo if distro is Debian Jessie
-  become: yes
-  apt_repository: repo="deb http://ftp.debian.org/debian jessie-backports main" state=present update_cache=yes
-  when: ansible_distribution_release == "jessie"
-
-- name: Install Java 8 on jessie from backports
-  become: yes
-  apt: name={{ item }} state=present default_release=jessie-backports
-  with_items:
-    - openjdk-8-jdk
-  when: ansible_distribution_release == "jessie"
-
 - name: Install Java 8
   become: yes
-  apt: name=openjdk-8-jdk state=present 
+  apt: name=openjdk-8-jdk state=present
 
-- name: Make Java 8 the system default 
+- name: Make Java 8 the system default
   become: yes
   shell: update-java-alternatives --set java-1.8.0-openjdk-amd64 && touch /etc/.set_javadefault_ansible
   args:


### PR DESCRIPTION
Jessie backports no longer available. FOLIO-1889.