### PR TITLE
Edge nginx runlevel1

### DIFF
--- a/group_vars/release
+++ b/group_vars/release
@@ -3,8 +3,8 @@
 auth_required: true
 load_mods_larger: true
 enable_okapi: true
-deploy_url: https://raw.githubusercontent.com/folio-org/platform-core/q1-2019/okapi-install.json
-enable_url: https://raw.githubusercontent.com/folio-org/platform-core/q1-2019/stripes-install.json
+deploy_url: https://raw.githubusercontent.com/folio-org/platform-complete/q1-2019/okapi-install.json
+enable_url: https://raw.githubusercontent.com/folio-org/platform-complete/q1-2019/stripes-install.json
 update_launch_descr: true
 okapi_version: 2.26.1-1
 

--- a/roles/edge-nginx/tasks/main.yml
+++ b/roles/edge-nginx/tasks/main.yml
@@ -3,12 +3,11 @@
 
 - name: Install nginx from apt
   become: yes
-  apt: name=nginx
-
-- name: Ensure nginx is running
-  become: yes
-  service: name=nginx state=started
-  ignore_errors: yes
+  apt: 
+    name: nginx
+    state: present
+  environment: 
+    RUNLEVEL: 1 
 
 - name: disable nginx default vhost
   become: yes
@@ -16,6 +15,11 @@
     path: /etc/nginx/sites-enabled/default
     state: absent
   notify: Restart nginx
+
+- name: Ensure nginx is running
+  become: yes
+  service: name=nginx state=started
+  ignore_errors: yes
 
 - name: Install edge module configuration for nginx
   become: yes


### PR DESCRIPTION
- when installing nginx from apt don't start it up automatically in case there is anything bound to port 80.

- fix 'release' group_vars