### PR TITLE
Reverse order of mod-authtoken and mod-permissions in testing build.

### DIFF
--- a/group_vars/testing
+++ b/group_vars/testing
@@ -19,16 +19,16 @@ include_edge_elb: true
 pg_max_pool_size: 5
 
 folio_modules:
-  - name: mod-authtoken
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    deploy: yes
-
   - name: mod-permissions
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx512m" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
+    deploy: yes
+
+  - name: mod-authtoken
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
     deploy: yes
 
   - name: mod-login

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -16,16 +16,16 @@ update_launch_descr: true
 pg_max_pool_size: 5
 
 folio_modules:
-  - name: mod-authtoken
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    deploy: yes
-
   - name: mod-permissions
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx512m" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
+    deploy: yes
+
+  - name: mod-authtoken
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
     deploy: yes
 
   - name: mod-login


### PR DESCRIPTION
mod-authtoken now requires the permissions interface, so mod-permissions must be registered first. Fixes FOLIO-2084.