### PR TITLE
FOLIO-2014 remove mod-vendors

### DIFF
--- a/group_vars/next-release-complete
+++ b/group_vars/next-release-complete
@@ -186,6 +186,14 @@ folio_modules:
       - { name: loadSample, value: "true" }
     deploy: yes
 
+  - name: mod-organizations-storage
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    tenant_parameters:
+      - { name: loadReference, value: "true" }
+      - { name: loadSample, value: "true" }
+    deploy: yes
+
   - name: mod-password-validator
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
@@ -248,12 +256,4 @@ folio_modules:
   - name: mod-users-bl
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    deploy: yes
-
-  - name: mod-vendors
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    tenant_parameters:
-      - { name: loadReference, value: "true" }
-      - { name: loadSample, value: "true" }
     deploy: yes

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -277,14 +277,6 @@ folio_modules:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
     deploy: yes
 
-  - name: mod-vendors
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    tenant_parameters:
-      - { name: loadSample, value: "true" }
-    deploy: yes
-
-
 # Variables for building UI
 stripes_github_project: https://github.com/folio-org/platform-complete
 stripes_github_version: snapshot

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -157,13 +157,6 @@ folio_modules:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
     deploy: yes
 
-  - name: mod-vendors
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    tenant_parameters:
-      - { name: loadSample, value: "true" }
-    deploy: yes
-
   - name: mod-organizations-storage
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }


### PR DESCRIPTION
Removed mod-vendors config from group_vars/snapshot and testing. The replacement mod-organizations-storage was already added FOLIO-1938.

For completeness, added definition of mod-organizations-storage to group_vars/next-release-complete