### PR TITLE
adds okapi-kubernetes role for FOLIO-2069

### DIFF
--- a/roles/okapi-kubernetes/README.md
+++ b/roles/okapi-kubernetes/README.md
@@ -1,0 +1,39 @@
+# Okapi Kubernetes
+This role deploys okapi running in cluster mode into a Kubernetes namespace. It will provision a database on the specified postgres host if one does not already exist. This role assumes there is a Kubernetes cluster and Postgres instance available. Configure connection information for Kubernetes in `~/.kube/config`.
+
+## Usage
+```yml
+---
+- hosts: localhost
+  connection: local
+  roles:
+    - role: okapi-kubernetes
+      pg_host: mypghost.domain.tld
+      pg_admin_user: my_admin_user
+      pg_admin_password: my_pg_pass
+```
+
+## Defaults
+```yml
+---
+namespace: default
+kubeconfig: ~/.kube/config
+
+app_label: okapi
+
+deployment_name: okapi
+
+okapi_url: http://okapi:9130
+okapi_db_user: okapi
+okapi_db_password: okapi25
+okapi_db_database: okapi
+
+pg_admin_user: pgadminuser
+pg_admin_password: pgadminpass
+pg_host: localhost
+pg_port: 5432
+
+
+service_name: okapi
+service_type: ClusterIP
+```

--- a/roles/okapi-kubernetes/defaults/main.yml
+++ b/roles/okapi-kubernetes/defaults/main.yml
@@ -10,6 +10,9 @@ okapi_url: http://okapi:9130
 okapi_db_user: okapi
 okapi_db_password: okapi25
 okapi_db_database: okapi
+okapi_docker_repository: folioci
+okapi_docker_image: okapi
+okapi_docker_tag: latest
 
 pg_admin_user: pgadminuser
 pg_admin_password: pgadminpass

--- a/roles/okapi-kubernetes/defaults/main.yml
+++ b/roles/okapi-kubernetes/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+namespace: default
+kubeconfig: ~/.kube/config
+
+app_label: okapi
+
+deployment_name: okapi
+
+okapi_url: http://okapi:9130
+okapi_db_user: okapi
+okapi_db_password: okapi25
+okapi_db_database: okapi
+
+pg_admin_user: pgadminuser
+pg_admin_password: pgadminpass
+pg_host: localhost
+pg_port: 5432
+
+
+service_name: okapi
+service_type: ClusterIP

--- a/roles/okapi-kubernetes/tasks/main.yml
+++ b/roles/okapi-kubernetes/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Create Okapi postgresql user
+  postgresql_user:
+    db: postgres
+    login_host: "{{ pg_host }}"
+    login_user: "{{ pg_admin_user }}"
+    login_password: "{{ pg_admin_password }}"
+    name: "{{ okapi_db_user }}"
+    password: "{{ okapi_db_password }}"
+    role_attr_flags: CREATEDB
+    no_password_changes: yes
+
+- name: Create Okapi db
+  postgresql_db:
+    login_host: "{{ pg_host }}"
+    login_user: "{{ okapi_db_user }}"
+    login_password: "{{ okapi_db_password }}"
+    name: "{{ okapi_db_database }}"
+    owner: "{{ okapi_db_user }}"
+
+- name: create hazelcast service account
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'rbac.yml.j2') }}"
+
+- name: create okapi service
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'okapi-service.yml.j2') }}"
+
+- name: create hazelcast configmap
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'hazelcast-configmap.yml.j2') }}"
+
+- name: create okapi deployment
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'okapi-deployment.yml.j2') }}"

--- a/roles/okapi-kubernetes/templates/hazelcast-configmap.yml.j2
+++ b/roles/okapi-kubernetes/templates/hazelcast-configmap.yml.j2
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hazelcast
+  namespace: "{{ namespace }}"
+data:
+  hazelcast.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.12.xsd">
+      <semaphore name="__vertx.*">
+         <initial-permits>1</initial-permits>
+      </semaphore>
+      <network>
+        <join>
+          <multicast enabled="false"/>
+          <kubernetes enabled="true">
+            <namespace>{{ namespace }}</namespace>
+            <service-name>{{ service_name }}</service-name>
+          </kubernetes>
+        </join>
+      </network>
+    </hazelcast>

--- a/roles/okapi-kubernetes/templates/okapi-deployment.yml.j2
+++ b/roles/okapi-kubernetes/templates/okapi-deployment.yml.j2
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: "{{ deployment_name }}"
+  labels:
+    app: "{{ app_label }}"
+  namespace: "{{ namespace }}"
+spec:
+  selector:
+    matchLabels:
+      app: "{{ app_label }}"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: "{{ app_label }}"
+    spec:
+      containers:
+        - name: okapi
+          image: folioci/okapi
+          args:
+            - cluster -hazelcast-config-file /etc/hazelcast.xml
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: JAVA_OPTIONS
+            value: >
+              -Djava.awt.headless=true -Dstorage=postgres 
+              -Dpostgres_host={{ pg_host }} 
+              -Dpostgres_port={{ pg_port }}
+              -Dpostgres_user={{ okapi_db_user }} 
+              -Dpostgres_password={{ okapi_db_password }} 
+              -Dpostgres_database={{ okapi_db_database }}
+              -Dokapi_url={{ okapi_url }}
+              -Dnodename=$(POD_NAME)
+          ports:
+          - containerPort: 9130
+            protocol: TCP
+          - containerPort: 5701
+            protocol: TCP
+          volumeMounts:
+          - name: "hazelcast"
+            mountPath: "/etc/hazelcast.xml"
+            subPath: "hazelcast.xml"
+      volumes:
+      - name: "hazelcast"
+        configMap:
+          name: "hazelcast"

--- a/roles/okapi-kubernetes/templates/okapi-deployment.yml.j2
+++ b/roles/okapi-kubernetes/templates/okapi-deployment.yml.j2
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: okapi
-          image: folioci/okapi
+          image: {{ okapi_docker_repository }}/{{ okapi_docker_image }}:{{ okapi_docker_tag }}
           args:
             - cluster -hazelcast-config-file /etc/hazelcast.xml
           env:

--- a/roles/okapi-kubernetes/templates/okapi-service.yml.j2
+++ b/roles/okapi-kubernetes/templates/okapi-service.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ service_name }}"
+  namespace: "{{ namespace }}"
+spec:
+  type: "{{ service_type }}"
+  selector:
+    app: "{{ app_label }}"
+  ports:
+  - name: hazelcast
+    port: 5701
+  - name: okapi
+    port: 9130

--- a/roles/okapi-kubernetes/templates/rbac.yml.j2
+++ b/roles/okapi-kubernetes/templates/rbac.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hazelcast-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: "{{ namespace }}"


### PR DESCRIPTION
To review before merging:

* DB creation. This creates the okapi database via ansible. The RDS database is only open to the subnet that k8s is on. The role will need to be run against something in the k8s cluster (one of the nodes, or perhaps localhost if jenkins is running in k8s). Or, we could open the DB to jenkins. For testing I've been running it against localhost and creating a DB on a test RDS db that is open.

* Ingress: the service created here might need to be adjusted depending on how ingress is handled.