### PR TITLE
For testing build, enable mod-circulation-storage before mod-template-engine.

### DIFF
--- a/folio.yml
+++ b/folio.yml
@@ -54,7 +54,7 @@
 
 # Edge modules
 - name: Set up Okapi to support edge modules
-  hosts: testing-core:testing
+  hosts: testing
   roles:
     - role: okapi-register-modules
       folio_modules:
@@ -77,7 +77,7 @@
     - tenant-admin-permissions
 
 - name: Set up edge modules
-  hosts: testing-core:testing:snapshot
+  hosts: testing:snapshot
   roles:
     - role: edge-module
       edge_module: edge-rtac

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -61,6 +61,14 @@ folio_modules:
       - { name: loadSample, value: "true" }
     deploy: yes
 
+  - name: mod-circulation-storage
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    tenant_parameters:
+      - { name: loadReference, value: "true" }
+      - { name: loadSample, value: "true" }
+    deploy: yes
+
   - name: mod-password-validator
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
@@ -119,14 +127,6 @@ folio_modules:
   - name: mod-feesfines
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    deploy: yes
-
-  - name: mod-circulation-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    tenant_parameters:
-      - { name: loadReference, value: "true" }
-      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-circulation

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -58,6 +58,14 @@ folio_modules:
       - { name: loadSample, value: "true" }
     deploy: yes
 
+  - name: mod-circulation-storage
+    docker_env:
+      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
+    tenant_parameters:
+      - { name: loadReference, value: "true" }
+      - { name: loadSample, value: "true" }
+    deploy: yes
+
   - name: mod-password-validator
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
@@ -111,14 +119,6 @@ folio_modules:
   - name: mod-feesfines
     docker_env:
       - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    deploy: yes
-
-  - name: mod-circulation-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-Xmx256m" }
-    tenant_parameters:
-      - { name: loadReference, value: "true" }
-      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-circulation


### PR DESCRIPTION
A new dependency has been introduced. Also remove edge modules from "testing-core" configuration. FOLIO-2179.