### PR TITLE
FOLIO-2186 Follow role name change to create-database

### DIFF
--- a/roles/create-database/README.md
+++ b/roles/create-database/README.md
@@ -20,14 +20,14 @@ Invoke the role in a playbook, e.g.:
 ```yaml
 - hosts: my-folio-test
   roles:
-    - role: module-database
+    - role: create-database
 ```
 
 Or include it as a dependency in a role, e.g.:
 
 ```yaml
 dependencies:
-  - { role: module-database }
+  - { role: create-database }
 ```
 
 ## Variables

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -50,7 +50,7 @@
     line: "host  all  all  0.0.0.0/0  md5"
   notify: Restart postgresql
 
-# This is the pg_admin_user that will be used in module-database role
+# This is the pg_admin_user that will be used in create-database role
 - name: Create a postgres admin user that can create roles and databases
   become: yes
   become_user: postgres


### PR DESCRIPTION
Fixes documentation. The "create-database" role, and the name change from "module-database", was already done in #248.