### PR TITLE
re-enable sourcemaps on folio-testing builds

### DIFF
--- a/group_vars/testing
+++ b/group_vars/testing
@@ -215,6 +215,7 @@ stripes_github_project: https://github.com/folio-org/platform-complete
 stripes_github_version: snapshot
 folio_npm_repo: npm-folioci
 platform_remove_lock: false
+with_sourcemap: true
 # mod descrs are built by `yarn install` in folio-testing-platform
 # build_module_descriptors: false
 okapi_register_modules: true

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -153,6 +153,7 @@ stripes_github_project: https://github.com/folio-org/platform-core
 stripes_github_version: snapshot
 folio_npm_repo: npm-folioci
 platform_remove_lock: false
+with_sourcemap: true
 # mod descrs are built by `yarn install` in folio-testing-platform
 # build_module_descriptors: false
 okapi_register_modules: true


### PR DESCRIPTION
We disabled sourcemaps on folio-testing due to a build error.  This issue has been resolved.  Re-enable sourcemaps on folio-testing builds. 