### PR TITLE
FOLIO-2226 Add mod-finance to snapshot 2

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -26,6 +26,7 @@ add_modules:
   - mod-graphql
   - mod-invoice-storage
   - mod-invoice
+  - mod-finance
   - edge-oai-pmh
   - edge-orders
   - edge-patron


### PR DESCRIPTION
Is not yet included by ui-finance, so also add to folio-ansible/group_vars/snapshot#add_modules