### PR TITLE
add module name (no version) for cleanup

### DIFF
--- a/roles/module-kubernetes/templates/module-deployment.yml.j2
+++ b/roles/module-kubernetes/templates/module-deployment.yml.j2
@@ -4,6 +4,7 @@ metadata:
   name: {{ module_item.name }}-{{ module_item.version.replace('.','-').lower() }}
   labels:
     app: {{ module_item.name }}-{{ module_item.version.replace('.','-').lower() }}
+    module: {{ module_item.name }}
   namespace: "{{ namespace }}"
 spec:
   selector:


### PR DESCRIPTION
Adds an additional label to k8s deployment yml to make cleanup easier. Including module name allows for comparing different versions of the same module w/o using regex on the cleanup script side.