### PR TITLE
FOLIO-2284: Override Docker memory limits set in launch descriptor

### DIFF
--- a/roles/okapi-deployment/tasks/main.yml
+++ b/roles/okapi-deployment/tasks/main.yml
@@ -59,9 +59,15 @@
   when: item.deploy|default(false) and item.docker_cmd is defined
   with_items: "{{ folio_modules }}"
 
+- name: Add dockerArgs/HostConfig/Memory to dep_descrs
+  set_fact:
+    dep_descrs_mem: "{{ dep_descrs_mem|default({})|combine({item.name: {'descriptor': {'dockerArgs': {'HostConfig': {'Memory': item.docker_mem}}}}}) }}"
+  when: item.deploy|default(false) and item.docker_mem is defined
+  with_items: "{{ folio_modules }}"
+
 - name: Combine dep_descrs dicts
   set_fact:
-    dep_descrs: "{{ dep_descrs|combine(dep_descrs_env|default({}), dep_descrs_cmd|default({}), recursive=True) }}"
+    dep_descrs: "{{ dep_descrs|combine(dep_descrs_env|default({}), dep_descrs_cmd|default({}), dep_descrs_mem|default({}), recursive=True) }}"
 
 - name: Check for module deployment
   uri:

--- a/roles/okapi-register-modules/README.md
+++ b/roles/okapi-register-modules/README.md
@@ -32,8 +32,10 @@ Invoke the role in a playbook, e.g.:
           docker_env:
             - { name: JAVA_OPTIONS, value: "-Xmx256m" }
           # override dockerPull, unfortunately for legacy purposes needs to be a string
-          # anything other than "true" is false 
+          # anything other than "true" is false
           okapi_docker_pull: "true"
+          # override dockerArgs/HostConfig/Memory key
+          docker_mem: 536870912
 ```
 
 For legacy reasons, the role puts the variable `folio_modules_withid` into the environment for other roles and tasks to use (it is used by the deprecated `okapi-deploy-modules` role).

--- a/roles/okapi-register-modules/tasks/main.yml
+++ b/roles/okapi-register-modules/tasks/main.yml
@@ -26,6 +26,10 @@
   set_fact:
     mod_descrs_pull: []
 
+- name: Init mod_descrs_mem
+  set_fact:
+    mod_descrs_mem: []
+
 - name: Init folio_modules_withid
   set_fact:
     folio_modules_withid: []
@@ -52,7 +56,7 @@
 
 # Update launch descriptors with customizations from folio_modules list
 # could be extended to support swapping exec for dockerImage, etc.
-# For now just supports env variables, dockerCMD, and dockerPull
+# For now just supports env variables, dockerArgs/HostConfig/Memory, dockerCMD, and dockerPull
 - name: Update env for embedded launch descriptors
   set_fact:
     mod_descrs_env: "{{ mod_descrs_env|default([]) }} + [ {% if mod_descrs[item.0].launchDescriptor is defined and item.1.docker_env is defined %}{{ mod_descrs[item.0]|combine({'launchDescriptor': {'env': item.1.docker_env}},recursive=True) }}{% else %}{{ mod_descrs[item.0] }}{% endif %} ]"
@@ -71,9 +75,15 @@
   with_indexed_items: "{{ folio_modules }}"
   when: update_launch_descr
 
+- name: Update dockerArgs/HostConfig/Memory for embedded launch descriptors
+  set_fact:
+    mod_descrs_mem: "{{ mod_descrs_mem|default([]) }} + [ {% if mod_descrs_pull[item.0].launchDescriptor is defined and item.1.docker_mem is defined %}{{ mod_descrs_pull[item.0]|combine({'launchDescriptor': {'dockerArgs': {'HostConfig': {'Memory': item.1.docker_mem}}}},recursive=True) }}{% else %}{{ mod_descrs_pull[item.0] }}{% endif %} ]"
+  with_indexed_items: "{{ folio_modules }}"
+  when: update_launch_descr
+
 - name: Reset mod_descrs variable
   set_fact:
-    mod_descrs: "{{ mod_descrs_pull }}"
+    mod_descrs: "{{ mod_descrs_mem }}"
   when: update_launch_descr
 
 # This task can be removed when okapi-deploy-modules role is removed


### PR DESCRIPTION
Add support for the `docker_mem` key of the `folio_modules` variable to both `okapi-register-modules` and `okapi-deployment` roles. This key allows the user to override the Docker memory limits that are set in a module's launch descriptor.