### PR TITLE
add loadSample param for MODCONF-33

### DIFF
--- a/group_vars/release
+++ b/group_vars/release
@@ -94,6 +94,8 @@ folio_modules:
   - name: mod-configuration
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-data-import

--- a/group_vars/release-core
+++ b/group_vars/release-core
@@ -58,6 +58,8 @@ folio_modules:
   - name: mod-configuration
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-email

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -86,6 +86,8 @@ folio_modules:
   - name: mod-configuration
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-courses

--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -59,6 +59,8 @@ folio_modules:
   - name: mod-configuration
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-email

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -35,6 +35,8 @@ folio_modules:
   - name: mod-configuration
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-users

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -32,6 +32,8 @@ folio_modules:
   - name: mod-configuration
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-users


### PR DESCRIPTION
mod-configuration uses the loadSample tenant init feature now, documenting this in folio-ansible group vars.