### PR TITLE
FOLIO-2358 Remove group_vars over-ride docker-env 1

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -51,8 +51,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-calendar
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-circulation
@@ -74,13 +72,9 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-inventory
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-codex-mux
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-configuration
@@ -127,8 +121,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-finance-storage
@@ -205,13 +197,11 @@ folio_modules:
     deploy: yes
 
   - name: mod-notes
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+#    docker_env:
+#      - { name: JAVA_OPTIONS, value: "-XX:MaxRAMPercentage=66.0" }
     deploy: yes
 
   - name: mod-notify
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-oai-pmh
@@ -274,8 +264,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-tags
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes

--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -29,8 +29,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-calendar
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-circulation
@@ -47,13 +45,9 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-inventory
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-codex-mux
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-configuration
@@ -74,8 +68,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-graphql
@@ -109,13 +101,11 @@ folio_modules:
     deploy: yes
 
   - name: mod-notes
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+#    docker_env:
+#      - { name: JAVA_OPTIONS, value: "-XX:MaxRAMPercentage=66.0" }
     deploy: yes
 
   - name: mod-notify
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-password-validator
@@ -147,8 +137,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-tags
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -98,8 +98,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-notify
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-users-bl
@@ -118,8 +116,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-calendar
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-courses
@@ -139,8 +135,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-circulation
@@ -149,16 +143,14 @@ folio_modules:
     deploy: yes
 
   - name: mod-notes
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+#    docker_env:
+#      - { name: JAVA_OPTIONS, value: "-XX:MaxRAMPercentage=66.0" }
     deploy: yes
 
   - name: mod-graphql
     deploy: yes
 
   - name: mod-codex-inventory
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-codex-ekb
@@ -167,8 +159,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-mux
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-kb-ebsco-java
@@ -203,8 +193,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-tags
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -95,8 +95,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-notify
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-users-bl
@@ -110,8 +108,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-calendar
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-source-record-storage
@@ -126,8 +122,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-circulation
@@ -136,23 +130,17 @@ folio_modules:
     deploy: yes
 
   - name: mod-notes
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
+#    docker_env:
+#      - { name: JAVA_OPTIONS, value: "-XX:MaxRAMPercentage=66.0" }
     deploy: yes
 
   - name: mod-codex-inventory
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-codex-mux
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-tags
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes


### PR DESCRIPTION
The JAVA_OPTIONS are now configured via each module's default LaunchDescriptor.

mod-notes commented-out as default example.