### PR TITLE
FOLIO-2358 Remove group_vars over-ride docker-env 3

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -184,8 +184,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-marccat
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-notes

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -153,8 +153,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-marccat
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-organizations-storage


### PR DESCRIPTION
The JAVA_OPTIONS are now configured via each module's default LaunchDescriptor.