### PR TITLE
FOLIO-2358 Remove group_vars over-ride docker-env 5

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -89,14 +89,9 @@ folio_modules:
     deploy: yes
 
   - name: mod-data-import
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-data-import-converter-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
-      - { name: "test.mode", value: "true" }
     deploy: yes
 
   - name: mod-email
@@ -223,23 +218,15 @@ folio_modules:
     deploy: yes
 
   - name: mod-rtac
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-sender
     deploy: yes
 
   - name: mod-source-record-manager
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
-      - { name: "test.mode", value: "true" }
     deploy: yes
 
   - name: mod-source-record-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
-      - { name: "test.mode", value: "true" }
     deploy: yes
 
   - name: mod-tags

--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -97,17 +97,12 @@ folio_modules:
     deploy: yes
 
   - name: mod-rtac
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-sender
     deploy: yes
 
   - name: mod-source-record-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
-      - { name: "test.mode", value: "true" }
     deploy: yes
 
   - name: mod-tags

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -96,9 +96,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-source-record-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
-      - { name: "test.mode", value: "true" }
     deploy: yes
 
   - name: mod-inventory

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -83,9 +83,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-source-record-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
-      - { name: "test.mode", value: "true" }
     deploy: yes
 
   - name: mod-inventory


### PR DESCRIPTION
The JAVA_OPTIONS are now configured via each module's default LaunchDescriptor.