### PR TITLE
FOLIO-2358 Remove group_vars over-ride docker-env 6

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -68,8 +68,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-ekb
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-codex-inventory
@@ -98,13 +96,9 @@ folio_modules:
     deploy: yes
 
   - name: mod-erm-usage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-erm-usage-harvester
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-event-config
@@ -185,8 +179,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-oai-pmh
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-orders

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -82,8 +82,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-courses
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-data-import

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -83,8 +83,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-user-import
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-calendar
@@ -119,8 +117,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-ekb
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-codex-mux
@@ -161,8 +157,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-oai-pmh
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: edge-oai-pmh

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -89,8 +89,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-courses
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     deploy: yes
 
   - name: mod-source-record-storage


### PR DESCRIPTION
The JAVA_OPTIONS are now configured via each module's default LaunchDescriptor.