### PR TITLE
FOLIO-2358 Remove group_vars over-ride docker-env 8

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -171,16 +171,12 @@ folio_modules:
     deploy: yes
 
   - name: mod-organizations-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadReference, value: "true" }
       - { name: loadSample, value: "true" }
     deploy: yes
 
   - name: mod-orders-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -127,8 +127,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-organizations-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadReference, value: "true" }
       - { name: loadSample, value: "true" }
@@ -154,8 +152,6 @@ folio_modules:
   - name: edge-oai-pmh
 
   - name: mod-orders-storage
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" }
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes


### PR DESCRIPTION
The JAVA_OPTIONS are now configured via each module's default LaunchDescriptor.