### PR TITLE
FOLIO-2368: Okapi 2.35.1-1, fixes Netty CVE-2019-16869

### DIFF
--- a/group_vars/release
+++ b/group_vars/release
@@ -7,7 +7,7 @@ folio_install_type: single_server
 deploy_url: https://raw.githubusercontent.com/folio-org/platform-complete/q3.2-2019/okapi-install.json
 enable_url: https://raw.githubusercontent.com/folio-org/platform-complete/q3.2-2019/stripes-install.json
 update_launch_descr: true
-okapi_version: 2.32.0-1
+okapi_version: 2.35.1-1
 
 # proxy edge modules - folio-elb
 include_edge_elb: true

--- a/group_vars/release-core
+++ b/group_vars/release-core
@@ -7,7 +7,7 @@ folio_install_type: single_server
 deploy_url: https://raw.githubusercontent.com/folio-org/platform-core/q3.2-2019/okapi-install.json
 enable_url: https://raw.githubusercontent.com/folio-org/platform-core/q3.2-2019/stripes-install.json
 update_launch_descr: true
-okapi_version: 2.32.0-1
+okapi_version: 2.35.1-1
 save_install: no
 
 


### PR DESCRIPTION
Netty before 4.1.42.Final mishandles whitespace before the colon in HTTP headers
(such as a "Transfer-Encoding : chunked" line), which leads to HTTP request smuggling.
https://nvd.nist.gov/vuln/detail/CVE-2019-16869
https://issues.folio.org/browse/FOLIO-2368

Okapi 2.35.1 updates Netty to 4.1.42.Final by updating Vert.x to 3.8.4.