### PR TITLE
FOLIO-2358 Remove group_vars over-ride docker_env for released 3

### DIFF
--- a/group_vars/next-release-complete
+++ b/group_vars/next-release-complete
@@ -164,8 +164,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-patron
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-permissions


### PR DESCRIPTION
Adjust config only for those modules that have a new release deployed via platform

The JAVA_OPTIONS are now configured via each released module's default LaunchDescriptor.
