### PR TITLE
FOLIO-2358 Remove group_vars over-ride docker_env for released 4

### DIFF
--- a/group_vars/next-release-complete
+++ b/group_vars/next-release-complete
@@ -42,8 +42,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-calendar
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-circulation

--- a/group_vars/next-release-complete
+++ b/group_vars/next-release-complete
@@ -57,6 +57,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-inventory
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
@@ -86,6 +87,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
@@ -131,6 +133,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-login-saml
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
@@ -190,6 +193,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-user-import
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes

--- a/group_vars/next-release-core
+++ b/group_vars/next-release-core
@@ -20,6 +20,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-calendar
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
@@ -34,6 +35,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-inventory
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
@@ -51,6 +53,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
@@ -72,6 +75,7 @@ folio_modules:
     deploy: yes
 
   - name: mod-login-saml
+    # Awaits FOLIO-2394
     docker_env:
       - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes


### PR DESCRIPTION
Adjust config only for those modules that have a new release deployed via platform

The JAVA_OPTIONS are now configured via each released module's default LaunchDescriptor.

Denote that others await FOLIO-2394