### PR TITLE
Fix Java property for postgres_username for Okapi Kubernetes deployment.

### DIFF
--- a/roles/okapi-kubernetes/templates/okapi-deployment.yml.j2
+++ b/roles/okapi-kubernetes/templates/okapi-deployment.yml.j2
@@ -31,7 +31,7 @@ spec:
               -Djava.awt.headless=true -Dstorage=postgres
               -Dpostgres_host={{ pg_host }}
               -Dpostgres_port={{ pg_port }}
-              -Dpostgres_user={{ okapidb_user }}
+              -Dpostgres_username={{ okapidb_user }}
               -Dpostgres_password={{ okapidb_password }}
               -Dpostgres_database={{ okapidb_name }}
               -Dhost={{ app_label }}


### PR DESCRIPTION
The property is `postgres_username`, not `postgres_user`. If you use the wrong property, Okapi defaults to the username "okapi". Apparently we've just been lucky so far.