### PR TITLE
FOLIO-2358 FOLIO-2394 Remove group_vars over-ride docker_env for released 1

### DIFF
--- a/group_vars/next-release-core
+++ b/group_vars/next-release-core
@@ -20,9 +20,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-calendar
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-circulation


### PR DESCRIPTION
Finally regression tests passed for platform-core master. So ui-calendar was merged. Hence new version of mod-calendar is now in folio-release refenv.

For group_vars/next-release-core
only for those modules that have a new release deployed via platform.