### PR TITLE
FOLIO-2358 FOLIO-2394 Remove group_vars over-ride docker_env for released 2

### DIFF
--- a/group_vars/next-release-complete
+++ b/group_vars/next-release-complete
@@ -59,9 +59,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-inventory
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-codex-mux
@@ -89,9 +86,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-finance-storage
@@ -135,9 +129,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-login-saml
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-ncip
@@ -198,9 +189,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-user-import
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-users

--- a/group_vars/next-release-core
+++ b/group_vars/next-release-core
@@ -32,9 +32,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-codex-inventory
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-codex-mux
@@ -50,9 +47,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-feesfines
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-inventory
@@ -72,9 +66,6 @@ folio_modules:
     deploy: yes
 
   - name: mod-login-saml
-    # Awaits FOLIO-2394
-    docker_env:
-      - { name: JAVA_OPTIONS, value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx256m" }
     deploy: yes
 
   - name: mod-notes


### PR DESCRIPTION
Adjust config for the remaining modules that finally have a new release deployed via platforms.

The JAVA_OPTIONS are now configured via each released module's default LaunchDescriptor.

See [FOLIO-2394](https://issues.folio.org/browse/FOLIO-2394).