### PR TITLE
Declare mod-quick-marc before mod-source-record-storage FOLIO-2540

### DIFF
--- a/group_vars/testing
+++ b/group_vars/testing
@@ -101,10 +101,10 @@ folio_modules:
       - name: OKAPI_URL
         value: "{{ okapi_url }}"
 
-  - name: mod-quick-marc
+  - name: mod-source-record-storage
     deploy: yes
 
-  - name: mod-source-record-storage
+  - name: mod-quick-marc
     deploy: yes
 
   - name: mod-data-export


### PR DESCRIPTION
When first enabled it required no interfaces, now needs source-storage-records interface.