### PR TITLE
Make create-tenant-admin role more flexible

### DIFF
--- a/roles/create-tenant-admin/tasks/main.yml
+++ b/roles/create-tenant-admin/tasks/main.yml
@@ -152,6 +152,7 @@
     - name: Set list of service point ids
       set_fact: service_points_ids={{ '\"' + service_points|json_query('json.servicepoints[*].id')|join('\", \"') + '\"' }}
       when: check_sp_users_int.json|default([])|length > 0 and check_sp_user.json.totalRecords == 0
+    # This can safely fail
     - name: Create service points user
       uri:
         url: "{{ okapi_url }}/service-points-users"
@@ -170,6 +171,7 @@
       register: create_sp_user
       changed_when: create_sp_user.status == 201
       when: check_sp_users_int.json|default([])|length > 0 and check_sp_user.json.totalRecords == 0
+      ignore_errors: yes
   always:
     ####################
     # Enable authtoken #


### PR DESCRIPTION
Allow it to succeed even if a service point user can't be created.