### PR TITLE
FOLIO-2617 ebsco-rmapi-config kb-credentials endpoint

### DIFF
--- a/roles/ebsco-rmapi-config/defaults/main.yml
+++ b/roles/ebsco-rmapi-config/defaults/main.yml
@@ -1,9 +1,8 @@
 ---
 okapi_port: 9130
 okapi_url: "http://{{ ansible_default_ipv4.address }}:{{ okapi_port }}"
-auth_required: false
-admin_user: 
-   username: diku_admin 
-   password: admin 
+admin_user:
+  username: diku_admin
+  password: admin
 tenant: diku
 

--- a/roles/ebsco-rmapi-config/meta/main.yml
+++ b/roles/ebsco-rmapi-config/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: tenant-admin-permissions }
+  - { role: set-patron-group }

--- a/roles/ebsco-rmapi-config/meta/main.yml
+++ b/roles/ebsco-rmapi-config/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: set-patron-group }
+  - { role: tenant-admin-permissions }

--- a/roles/ebsco-rmapi-config/tasks/main.yml
+++ b/roles/ebsco-rmapi-config/tasks/main.yml
@@ -1,19 +1,16 @@
 ---
-# wait a few seconds to make sure modules are spun up
-- wait_for: timeout=5
-
 - name: Login as {{ admin_user.username }}
-  uri: 
+  uri:
     url: "{{ okapi_url }}/authn/login"
     method: POST
     body_format: json
-    headers: 
+    headers:
       X-Okapi-Tenant: "{{ tenant }}"
       Accept: application/json
     body: "{ 'username' : '{{ admin_user.username }}', 'password' : '{{ admin_user.password }}' }"
     status_code: 201
   register: tenant_admin_login
-  when: auth_required
+  changed_when: tenant_admin_login.status == 201
 
 - name: Configure RM API credentials
   uri:
@@ -27,5 +24,5 @@
       Accept: application/json
     body: '{ "data": { "type": "kbCredentials", "attributes": { "name": "{{ tenant }}", "apiKey": "{{ rmapi_key }}", "url": "{{ rmapi_url }}", "customerId": "{{ rmapi_custid }}" } } }'
     status_code: 201,422
-  register: mod_codex_ekb_credentials 
+  register: mod_codex_ekb_credentials
   changed_when: mod_codex_ekb_credentials.status == 201

--- a/roles/ebsco-rmapi-config/tasks/main.yml
+++ b/roles/ebsco-rmapi-config/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-- wait_for: timeout=5
-
 - name: Login as {{ admin_user.username }}
   uri:
     url: "{{ okapi_url }}/authn/login"
@@ -23,8 +21,20 @@
       Authtoken-Refresh-Cache: "true"
       X-Okapi-Tenant: "{{ tenant }}"
       X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token | default('token') }}"
-      Accept: application/json
-    body: '{ "data": { "type": "kbCredentials", "attributes": { "name": "{{ tenant }}", "apiKey": "{{ rmapi_key }}", "url": "{{ rmapi_url }}", "customerId": "{{ rmapi_custid }}" } } }'
+      Accept: application/vnd.api+json
+      Content-Type: application/vnd.api+json
+    body: |
+      {
+        "data": {
+          "type": "kbCredentials",
+          "attributes": {
+            "name": "{{ tenant }}",
+            "apiKey": "{{ rmapi_key }}",
+            "url": "{{ rmapi_url }}",
+            "customerId": "{{ rmapi_custid }}"
+          }
+        }
+      }
     status_code: 201,422
   register: mod_codex_ekb_credentials
   changed_when: mod_codex_ekb_credentials.status == 201

--- a/roles/ebsco-rmapi-config/tasks/main.yml
+++ b/roles/ebsco-rmapi-config/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- wait_for: timeout=5
+
 - name: Login as {{ admin_user.username }}
   uri:
     url: "{{ okapi_url }}/authn/login"

--- a/roles/ebsco-rmapi-config/tasks/main.yml
+++ b/roles/ebsco-rmapi-config/tasks/main.yml
@@ -15,46 +15,17 @@
   register: tenant_admin_login
   when: auth_required
 
-# Add RM API key
-- name: Add RM API customer ID
-  uri: 
-    url: "{{ okapi_url }}/configurations/entries"
+- name: Configure RM API credentials
+  uri:
+    url: "{{ okapi_url }}/eholdings/kb-credentials"
     method: POST
     body_format: json
-    headers: 
+    headers:
       Authtoken-Refresh-Cache: "true"
       X-Okapi-Tenant: "{{ tenant }}"
       X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token | default('token') }}"
       Accept: application/json
-    body: '{ "module": "EKB", "configName": "api_access", "code": "kb.ebsco.customerId", "description": "EBSCO RM-API Customer ID", "enabled": true, "value": "{{ rmapi_custid }}" }'
+    body: '{ "data": { "type": "kbCredentials", "attributes": { "name": "{{ tenant }}", "apiKey": "{{ rmapi_key }}", "url": "{{ rmapi_url }}", "customerId": "{{ rmapi_custid }}" } } }'
     status_code: 201,422
-  register: mod_codex_ekb_custid 
-  changed_when: mod_codex_ekb_custid.status == 201
-   
-- name: Add RM API key
-  uri: 
-    url: "{{ okapi_url }}/configurations/entries"
-    method: POST
-    body_format: json
-    headers: 
-      X-Okapi-Tenant: "{{ tenant }}"
-      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token | default('token') }}"
-      Accept: application/json
-    body: '{ "module": "EKB", "configName": "api_access", "code": "kb.ebsco.apiKey", "description": "EBSCO RM-API API Key", "enabled": true, "value": "{{ rmapi_key }}" }'
-    status_code: 201,422
-  register: mod_codex_ekb_apikey
-  changed_when: mod_codex_ekb_apikey.status == 201
-
-- name: Add RM API URL
-  uri: 
-    url: "{{ okapi_url }}/configurations/entries"
-    method: POST
-    body_format: json
-    headers: 
-      X-Okapi-Tenant: "{{ tenant }}"
-      X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token | default('token') }}"
-      Accept: application/json
-    body: '{ "module": "EKB", "configName": "api_access", "code": "kb.ebsco.url", "description": "EBSCO RM-API URL", "enabled": true, "value": "{{ rmapi_url }}" }'
-    status_code: 201,422
-  register: mod_codex_ekb_url
-  changed_when: mod_codex_ekb_url.status == 201
+  register: mod_codex_ekb_credentials 
+  changed_when: mod_codex_ekb_credentials.status == 201

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -17,10 +17,7 @@
     update_cache: yes
   when: folio_install_type == "kubernetes"
 
-- name: Install n and mocha from npm
+- name: Install n from npm
   become: yes
-  npm: name={{ item }} global=yes state=present
-  with_items:
-    - "n"
-    - mocha
+  npm: name="n" global=yes state=present
   when: folio_install_type == "single_server"


### PR DESCRIPTION
See [FOLIO-2617](https://issues.folio.org/browse/FOLIO-2617).

Also, note that this PR also removes the install of "mocha" which caused trouble during test builds this morning.