### PR TITLE
FOLIO-2631 - switch to credentials-existence API

### DIFF
--- a/roles/create-tenant-admin/tasks/main.yml
+++ b/roles/create-tenant-admin/tasks/main.yml
@@ -79,7 +79,7 @@
       when: check_user.json.totalRecords == 0
     - name: Check for login record
       uri:
-        url: "{{ okapi_url }}/authn/credentials?query=userId%3d%3d{{ admin_user_id }}"
+        url: "{{ okapi_url }}/authn/credentials-existence?userId={{ admin_user_id }}"
         headers:
           Accept: "application/json, text/plain"
           X-Okapi-Tenant: "{{ tenant }}"
@@ -100,7 +100,7 @@
         status_code: 201
       register: create_login
       changed_when: create_login.status == 201
-      when: check_login.json.totalRecords == 0
+      when: check_login.json.credentialsExist == false
     - name: Check for permissions record
       uri:
         url: "{{ okapi_url }}/perms/users?query=userId%3d%3d{{ admin_user_id }}"

--- a/roles/edge-module/tasks/main.yml
+++ b/roles/edge-module/tasks/main.yml
@@ -62,7 +62,7 @@
 
 - name: Check institutional user login record
   uri:
-    url: "{{ okapi_url }}/authn/credentials?query=userId%3d%3d{{ inst_user_uuid }}"
+    url: "{{ okapi_url }}/authn/credentials-existence?userId={{ inst_user_uuid }}"
     headers:
       X-Okapi-Tenant: "{{ tenant }}"
       X-Okapi-Token: "{{ tenant_admin_login.x_okapi_token|default('token') }}"
@@ -85,7 +85,7 @@
         "password": "{{ inst_user.password }}"
       }
     status_code: 201
-  when: check_inst_login.json.totalRecords == 0
+  when: check_inst_login.json.credentialsExist == false
   register: create_inst_login
   changed_when: create_inst_login.status == 201
 


### PR DESCRIPTION
## Purpose
There are breaking changes introduced by MODLOGIN-128 and related issues.  Specifically, the ability to retrieve user credentials has been removed.  Instead the `GET /authn/credentials-existence?userId={userId}` should be used.

See https://issues.folio.org/browse/FOLIO-2631 and https://issues.folio.org/browse/MODLOGIN-128  for details