### PR TITLE
Skip system generated permissions

### DIFF
--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Get all permissionSets not included in other permissionSets excluding okapi
   # cql query for (childOf==[] not permissionName=okapi.*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=500"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%23%2A%29&length=500"
     method: GET
     headers:
       Accept: "application/json, text/plain"


### PR DESCRIPTION
Okapi introduced system generated permission sets that start with "SYS#". We do not need to include those as part of admin perms. This change is necessary for FOLIO-2633. The build failed because the number of perms including those system ones exceeds the 500 page limit.