### PR TITLE
FOLIO-2633 enable okapi-3 in refenv builds, fix role tenant-admin-permissions

### DIFF
--- a/roles/okapi/defaults/main.yml
+++ b/roles/okapi/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # add a version for the package, e.g. "2.17.0-1"
-okapi_version: "2.40.0-1"
+okapi_version:
 okapi_role: cluster
 # 'eth0' is the default ec2 network interface. May be different on other systems
 okapi_interface: eth0

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -13,7 +13,7 @@
     status_code: 201
   register: tenant_admin_login
 
-- name: Get all permissionSets not included in other permissionSets excluding okapi
+- name: "Get all permissionSets not included in other permissionSets excluding okapi (childOf==[] not permissionName=okapi.* not permissionName=SYS#*)"
   # cql query for (childOf==[] not permissionName=okapi.* not permissionName=SYS#*)
   uri:
     url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%23%2A%29&length=3000"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -14,9 +14,9 @@
   register: tenant_admin_login
 
 - name: Get all permissionSets not included in other permissionSets excluding okapi
-  # cql query for (childOf==[] not permissionName=okapi.* not permissionName=SYS#*)
+  # cql query for (childOf==[] not permissionName=okapi.* not permissionName=SYS*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%23%2A%29&length=500"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%2A%29&length=500"
     method: GET
     headers:
       Accept: "application/json, text/plain"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -14,9 +14,9 @@
   register: tenant_admin_login
 
 - name: Get all permissionSets not included in other permissionSets excluding okapi
-  # cql query for (childOf==[] not permissionName=okapi.* not permissionName=SYS*)
+  # cql query for (childOf==[] not permissionName=okapi.*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%2A%29&length=500"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A&length=2000"
     method: GET
     headers:
       Accept: "application/json, text/plain"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -14,7 +14,7 @@
   register: tenant_admin_login
 
 - name: Get all permissionSets not included in other permissionSets excluding okapi
-  # cql query for (childOf==[] not permissionName=okapi.*)
+  # cql query for (childOf==[] not permissionName=okapi.* not permissionName=SYS#*)
   uri:
     url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%23%2A%29&length=500"
     method: GET

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Get all permissionSets not included in other permissionSets excluding okapi
   # cql query for (childOf==[] not permissionName=okapi.*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=2000"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=3000"
     method: GET
     headers:
       Accept: "application/json, text/plain"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Get all permissionSets not included in other permissionSets excluding okapi
   # cql query for (childOf==[] not permissionName=okapi.*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=500"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=3000"
     method: GET
     headers:
       Accept: "application/json, text/plain"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Get all permissionSets not included in other permissionSets excluding okapi
   # cql query for (childOf==[] not permissionName=okapi.*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=3000"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=500"
     method: GET
     headers:
       Accept: "application/json, text/plain"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -13,10 +13,10 @@
     status_code: 201
   register: tenant_admin_login
 
-- name: "Get all permissionSets not included in other permissionSets excluding okapi (childOf==[] not permissionName=okapi.* not permissionName=SYS#*)"
-  # cql query for (childOf==[] not permissionName=okapi.* not permissionName=SYS#*)
+- name: "Get all permissionSets not included in other permissionSets excluding okapi (childOf==[] not permissionName==okapi.* not permissionName==SYS#*)"
+  # cql query for (childOf==[] not permissionName==okapi.* not permissionName==SYS#*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%23%2A%29&length=3000"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3D%3Dokapi.%2A%20not%20permissionName%3D%3DSYS%23%2A%29&length=5000"
     method: GET
     headers:
       Accept: "application/json, text/plain"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Get all permissionSets not included in other permissionSets excluding okapi
   # cql query for (childOf==[] not permissionName=okapi.*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A&length=2000"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=2000"
     method: GET
     headers:
       Accept: "application/json, text/plain"

--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -14,9 +14,9 @@
   register: tenant_admin_login
 
 - name: Get all permissionSets not included in other permissionSets excluding okapi
-  # cql query for (childOf==[] not permissionName=okapi.*)
+  # cql query for (childOf==[] not permissionName=okapi.* not permissionName=SYS#*)
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%29&length=3000"
+    url: "{{ okapi_url }}/perms/permissions?query=%28childOf%3D%3D%5B%5D%20not%20permissionName%3Dokapi.%2A%20not%20permissionName%3DSYS%23%2A%29&length=3000"
     method: GET
     headers:
       Accept: "application/json, text/plain"
@@ -26,7 +26,7 @@
 
 - name: Fail if all permissions not retrieved
   fail:
-    msg: "Retrieved permissions don't match total permissions count"
+    msg: "Retrieved permissions ({{ all_permissions.json.permissions|default([])|length }}) don't match total permissions count ({{ all_permissions.json.totalRecords|default('no totalRecords key') }})"
   when: all_permissions.json.permissions|length != all_permissions.json.totalRecords
 
 - name: Assign permissions to {{ admin_user.username }}


### PR DESCRIPTION
Unpin okapi to enable okapi-3
Role tenant-admin-permissions handles new system permissions from okapi-3
Improve ansible task names and messages