### PR TITLE
Do not initdb as part of Okapi installation.

### DIFF
--- a/roles/okapi/tasks/main.yml
+++ b/roles/okapi/tasks/main.yml
@@ -47,14 +47,6 @@
   notify: okapi restart
 
 
-- name: Initialize okapi database
-  become: yes
-  shell: /usr/share/folio/okapi/bin/okapi.sh --initdb && touch /var/lib/okapi/.db_init
-  args:
-    creates: /var/lib/okapi/.db_init
-  when: okapi_storage == "postgres"
-  notify: okapi restart
-
 - meta: flush_handlers
 
 - name: Make sure Okapi is started


### PR DESCRIPTION
Actually, for idempotence, we don't want to do this, anyway -- otherwise it reinitializes the tables!

Workaround for OKAPI-937