### PR TITLE
Create "add-users" role to create sample users for permissions testing.

### DIFF
--- a/folio.yml
+++ b/folio.yml
@@ -117,6 +117,11 @@
   roles:
     - mod-inventory-mods
 
+- name: Add sample users for permissions testing
+  hosts: testing:snapshot:release
+  roles:
+    - add-users
+
 # Set up stripes
 - name: Build stripes webpack, assign permissions
   hosts: stripes-build

--- a/roles/add-users/README.md
+++ b/roles/add-users/README.md
@@ -1,0 +1,30 @@
+# add-users
+
+Ansible role to run the `add-users.js` script from [folio-tools](https://github.com/folio-org/folio-tools). This script creates custom users from permissions sets defined in JSON-formatted files. See https://github.com/folio-org/folio-tools/tree/master/add-users for more details.
+
+## Prerequisites
+
+This role clones the folio-tools repository from GitHub and uses NodeJS to run the script. It requires both git and node to be installed on the target system. The [nodejs role](../nodejs) from this project is listed as a dependency.
+
+## Usage
+
+Invoke the role in a playbook, e.g.:
+
+```yaml
+- hosts: my-folio-test
+  roles:
+    - role: add-users
+```
+
+## Variables
+
+```yaml
+---
+# defaults
+okapi_port: 9130
+okapi_url: "http://{{ ansible_default_ipv4.address }}:{{ okapi_port }}"
+tenant: diku
+admin_user:
+  username: diku_admin
+  password: admin
+```

--- a/roles/add-users/defaults/main.yml
+++ b/roles/add-users/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults
+okapi_port: 9130
+okapi_url: "http://{{ ansible_default_ipv4.address }}:{{ okapi_port }}"
+tenant: diku
+admin_user:
+  username: diku_admin
+  password: admin

--- a/roles/add-users/meta/main.yml
+++ b/roles/add-users/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: nodejs

--- a/roles/add-users/tasks/main.yml
+++ b/roles/add-users/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Install prerequisites from apt
+  become: yes
+  apt:
+    name:
+      - git
+
+- name: Move node to latest LTS for Ansible user
+  shell: n lts
+
+- name: Clone folio-tools repository
+  git:
+    repo: "https://github.com/folio-org/folio-tools"
+    dest: folio-tools
+
+- name: Run add-users.js against Okapi
+  shell:
+    cmd: "node add-users.js --username \"{{ admin_user.username }}\" --password \"{{ admin_user.password }}\" --tenant \"{{ tenant }}\" --okapi \"{{ okapi_url }}\" --psets psets"
+    chdir: folio-tools/add-users


### PR DESCRIPTION
Add users to full (platform-complete) builds. Towards FOLIO-2807.