### PR TITLE
Adjust module registration order for testing builds

### DIFF
--- a/group_vars/testing
+++ b/group_vars/testing
@@ -37,6 +37,16 @@ folio_modules:
   - name: mod-authtoken
     deploy: yes
 
+  - name: mod-pubsub
+    deploy: yes
+    docker_env:
+      - name: KAFKA_HOST
+        value: "{{ kafka_host }}"
+      - name: KAFKA_PORT
+        value: "{{ kafka_port }}"
+      - name: OKAPI_URL
+        value: "{{ okapi_url }}"
+
   - name: mod-configuration
     tenant_parameters:
       - { name: loadSample, value: "true" }
@@ -93,16 +103,6 @@ folio_modules:
 
   - name: mod-courses
     deploy: yes
-
-  - name: mod-pubsub
-    deploy: yes
-    docker_env:
-      - name: KAFKA_HOST
-        value: "{{ kafka_host }}"
-      - name: KAFKA_PORT
-        value: "{{ kafka_port }}"
-      - name: OKAPI_URL
-        value: "{{ okapi_url }}"
 
   - name: mod-source-record-storage
     deploy: yes

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -34,6 +34,13 @@ folio_modules:
       - { name: loadSample, value: "true" }
     deploy: yes
 
+  - name: mod-login
+    docker_cmd:
+      - "verify.user=true"
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
+    deploy: yes
+
   - name: mod-authtoken
     deploy: yes
 
@@ -48,13 +55,6 @@ folio_modules:
         value: "{{ okapi_url }}"
 
   - name: mod-configuration
-    tenant_parameters:
-      - { name: loadSample, value: "true" }
-    deploy: yes
-
-  - name: mod-login
-    docker_cmd:
-      - "verify.user=true"
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -31,6 +31,13 @@ folio_modules:
       - { name: loadSample, value: "true" }
     deploy: yes
 
+  - name: mod-login
+    docker_cmd:
+      - "verify.user=true"
+    tenant_parameters:
+      - { name: loadSample, value: "true" }
+    deploy: yes
+
   - name: mod-authtoken
     deploy: yes
 
@@ -45,13 +52,6 @@ folio_modules:
         value: "{{ okapi_url }}"
 
   - name: mod-configuration
-    tenant_parameters:
-      - { name: loadSample, value: "true" }
-    deploy: yes
-
-  - name: mod-login
-    docker_cmd:
-      - "verify.user=true"
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -34,6 +34,16 @@ folio_modules:
   - name: mod-authtoken
     deploy: yes
 
+  - name: mod-pubsub
+    deploy: yes
+    docker_env:
+      - name: KAFKA_HOST
+        value: "{{ kafka_host }}"
+      - name: KAFKA_PORT
+        value: "{{ kafka_port }}"
+      - name: OKAPI_URL
+        value: "{{ okapi_url }}"
+
   - name: mod-configuration
     tenant_parameters:
       - { name: loadSample, value: "true" }
@@ -84,16 +94,6 @@ folio_modules:
 
   - name: mod-calendar
     deploy: yes
-
-  - name: mod-pubsub
-    deploy: yes
-    docker_env:
-      - name: KAFKA_HOST
-        value: "{{ kafka_host }}"
-      - name: KAFKA_PORT
-        value: "{{ kafka_port }}"
-      - name: OKAPI_URL
-        value: "{{ okapi_url }}"
 
   - name: mod-source-record-storage
     deploy: yes


### PR DESCRIPTION
mod-circulation-storage now depends on the pubsub interfaces, and mod-pubsub depends on permissions, users, and login.