### PR TITLE
Https patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The primary audiences for this project are:
 
 ## License
 
-Copyright (C) 2016-2019 The Open Library Foundation
+Copyright (C) 2016-2020 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
@@ -71,6 +71,88 @@ For more information, see [Vagrant VMs and Ansible roles](doc/index.md).
 
 In addition, this project includes a [Vagrantfile](Vagrantfile) for
 creating different environments.
+
+## Deployment on a server or virtual machine
+
+### Deploy host requirement
+
+* Linux or MacOSX
+* Ansible installed
+* ssh configured to access the server - preferred using ssh-keys
+
+### Server requirements
+
+* Ubuntu 16.04 for Folio Fameflower
+* Ubuntu 20.04 or Debian 10 for Folio Honeysuckle
+* Python installed
+* For SSL you need
+    * Certificate file and a Key file without Password
+    * FQDN
+
+### Installation
+
+To install Folio using the folio.yml Ansible playbook, you have to create a
+inventory file. You also have to configure some parameters. You can put
+these in the inventory file, in group vars files or in host vars files. In this
+example we use the inventory. The contents of the file `inventory.yml`:
+
+    all:
+      hosts:
+        my-host.domain.com:
+          superuser_username: opkapi_superuser
+          superuser_password: superpassword
+      children:
+        release:
+          my-host.domain.com:
+            save_dir: /etc/folio/savedir
+            okapi_interface: ens3
+            okapi_storage: postgres
+            tenant: mytenant
+            tenant_name: "My Organisation"
+            tenant_description: "Description of my Organisation"
+            okapi_role: dev
+        stripes:
+          my-host.domain.com:
+            stripes_host_address: 0.0.0.0
+            stripes_okapi_url: http://my-host.domain.com:9130
+            stripes_tenant: mytenant
+
+Next we can install Folio using the `folio.yml` playbook:
+    ansible-playbook -u ubuntu -i inventory.yml folio.yml
+
+To learn more about the parameters, you should have a look at the playbook,
+to see which roles are executed and in the documentation of the roles.
+
+Another example includes deployment of Stripes to use https instead of http:
+
+    all:
+      hosts:
+        my-host.domain.com:
+          superuser_username: opkapi_superuser
+          superuser_password: superpassword
+      children:
+        release:
+          my-host.domain.com:
+            save_dir: /etc/folio/savedir
+            okapi_interface: ens3
+            okapi_storage: postgres
+            tenant: mytenant
+            tenant_name: "My Organisation"
+            tenant_description: "Description of my Organisation"
+            okapi_role: dev
+        stripes:
+          my-host.domain.com:
+            stripes_host_address: 0.0.0.0
+            stripes_okapi_url: http://my-host.domain.com:9130
+            stripes_tenant: mytenant
+            stripes_enable_https: yes
+            stripes_certificate_file: /path/to/certificate.pem
+            stripes_certificate_key_file: /path/to/key.pem
+            nginx_proxy_okapi: yes
+            stripes_listen_port: 443
+            stripes_server_name: my-host.domain.com
+
+
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ example we use the inventory. The contents of the inventory file `inventory.yml`
     all:
       hosts:
         my-host.domain.com:
-          superuser_username: opkapi_superuser
-          superuser_password: superpassword
       children:
         release:
           hosts:
@@ -130,13 +128,12 @@ To learn more about the parameters, you should have a look at the
 playbook `folio.yml`, to see which roles are executed and in the
 documentation of the roles.
 
-Another example includes deployment of Stripes to use https instead of http:
+Another example includes deployment of Stripes to use https instead of http,
+securing okapis supertenant and the tenant admin user.
 
     all:
       hosts:
         my-host.domain.com:
-          superuser_username: opkapi_superuser
-          superuser_password: superpassword
       children:
         release:
           hosts:
@@ -148,6 +145,9 @@ Another example includes deployment of Stripes to use https instead of http:
               tenant_name: "My Organisation"
               tenant_description: "Description of my Organisation"
               okapi_role: dev
+              admin_user:
+                username: my_admin
+                password: tenantadminpassword
         stripes:
           hosts:
             my-host.domain.com:
@@ -160,6 +160,11 @@ Another example includes deployment of Stripes to use https instead of http:
               nginx_proxy_okapi: yes
               stripes_listen_port: 443
               stripes_server_name: my-host.domain.com
+        production:
+          hosts:
+            my-host.domain.com:
+              superuser_username: opkapi_superuser
+              superuser_password: superpassword
 
 
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ creating different environments.
 
 ### Deploy host requirement
 
+The deploy host is used to run the Ansible playbooks.
+
 * Linux or MacOSX
 * Ansible installed
 * ssh configured to access the server - preferred using ssh-keys
@@ -86,15 +88,16 @@ creating different environments.
 * Ubuntu 20.04 or Debian 10 for Folio Honeysuckle
 * Python installed
 * For SSL you need
-    * Certificate file and a Key file without Password
+    * Certificate file and a key file without Password
     * FQDN
 
 ### Installation
 
-To install Folio using the folio.yml Ansible playbook, you have to create a
-inventory file. You also have to configure some parameters. You can put
+To install Folio using the folio.yml Ansible playbook, you have to download
+and unpack the folio-ansible sources. Then create a inventory file.
+You also have to configure some parameters. You can put
 these in the inventory file, in group vars files or in host vars files. In this
-example we use the inventory. The contents of the file `inventory.yml`:
+example we use the inventory. The contents of the inventory file `inventory.yml`:
 
     all:
       hosts:
@@ -103,25 +106,29 @@ example we use the inventory. The contents of the file `inventory.yml`:
           superuser_password: superpassword
       children:
         release:
-          my-host.domain.com:
-            save_dir: /etc/folio/savedir
-            okapi_interface: ens3
-            okapi_storage: postgres
-            tenant: mytenant
-            tenant_name: "My Organisation"
-            tenant_description: "Description of my Organisation"
-            okapi_role: dev
+          hosts:
+            my-host.domain.com:
+              save_dir: /etc/folio/savedir
+              okapi_interface: ens3
+              okapi_storage: postgres
+              tenant: mytenant
+              tenant_name: "My Organisation"
+              tenant_description: "Description of my Organisation"
+              okapi_role: dev
         stripes:
-          my-host.domain.com:
-            stripes_host_address: 0.0.0.0
-            stripes_okapi_url: http://my-host.domain.com:9130
-            stripes_tenant: mytenant
+          hosts:
+            my-host.domain.com:
+              stripes_host_address: 0.0.0.0
+              stripes_okapi_url: http://my-host.domain.com:9130
+              stripes_tenant: mytenant
 
 Next we can install Folio using the `folio.yml` playbook:
+
     ansible-playbook -u ubuntu -i inventory.yml folio.yml
 
-To learn more about the parameters, you should have a look at the playbook,
-to see which roles are executed and in the documentation of the roles.
+To learn more about the parameters, you should have a look at the
+playbook `folio.yml`, to see which roles are executed and in the
+documentation of the roles.
 
 Another example includes deployment of Stripes to use https instead of http:
 
@@ -132,25 +139,27 @@ Another example includes deployment of Stripes to use https instead of http:
           superuser_password: superpassword
       children:
         release:
-          my-host.domain.com:
-            save_dir: /etc/folio/savedir
-            okapi_interface: ens3
-            okapi_storage: postgres
-            tenant: mytenant
-            tenant_name: "My Organisation"
-            tenant_description: "Description of my Organisation"
-            okapi_role: dev
+          hosts:
+            my-host.domain.com:
+              save_dir: /etc/folio/savedir
+              okapi_interface: ens3
+              okapi_storage: postgres
+              tenant: mytenant
+              tenant_name: "My Organisation"
+              tenant_description: "Description of my Organisation"
+              okapi_role: dev
         stripes:
-          my-host.domain.com:
-            stripes_host_address: 0.0.0.0
-            stripes_okapi_url: http://my-host.domain.com:9130
-            stripes_tenant: mytenant
-            stripes_enable_https: yes
-            stripes_certificate_file: /path/to/certificate.pem
-            stripes_certificate_key_file: /path/to/key.pem
-            nginx_proxy_okapi: yes
-            stripes_listen_port: 443
-            stripes_server_name: my-host.domain.com
+          hosts:
+            my-host.domain.com:
+              stripes_host_address: 0.0.0.0
+              stripes_okapi_url: http://my-host.domain.com:9130
+              stripes_tenant: mytenant
+              stripes_enable_https: yes
+              stripes_certificate_file: /path/to/certificate.pem
+              stripes_certificate_key_file: /path/to/key.pem
+              nginx_proxy_okapi: yes
+              stripes_listen_port: 443
+              stripes_server_name: my-host.domain.com
 
 
 

--- a/folio.yml
+++ b/folio.yml
@@ -142,6 +142,17 @@
   roles:
     - stripes-docker
 
+- name: Install Stripes on local installed nginx
+  hosts: stripes-nginx
+  roles:
+    - stripes-nginx
+    - tenant-admin-permissions
+
+- name: Secure Okapi Supertenant
+  hosts: production
+  roles:
+    - okapi-secure
+
 # Roles for packaging
 - hosts: vagrant
   tasks:

--- a/roles/stripes-docker/defaults/main.yml
+++ b/roles/stripes-docker/defaults/main.yml
@@ -2,9 +2,17 @@
 
 folio_conf: /etc/folio
 stripes_conf_dir: /etc/folio/stripes
-# host address to map container to. '127.0.0.1' by default  
+# host address to map container to. '127.0.0.1' by default
 stripes_host_address: '127.0.0.1'
 # Port to serve stripes container, default 80
-stripes_port: 80
+stripes_listen_port: 80
+stripes_enable_https: no
+stripes_certificate_file: null
+stripes_certificate_key_file: null
 stripes_rebuild: false
 nginx_servername: localhost
+stripes_server_name:
+  -  "{{ ansible_default_ipv4.address }}"
+nginx_proxy_okapi: no
+nginx_proxy_okapi_url: "http://{{ ansible_default_ipv4.address }}:9130"
+

--- a/roles/stripes-docker/defaults/main.yml
+++ b/roles/stripes-docker/defaults/main.yml
@@ -15,4 +15,5 @@ stripes_server_name:
   -  "{{ ansible_default_ipv4.address }}"
 nginx_proxy_okapi: no
 nginx_proxy_okapi_url: "http://{{ ansible_default_ipv4.address }}:9130"
+nginx_proxy_upload_max_size: 100M
 

--- a/roles/stripes-docker/files/Dockerfile
+++ b/roles/stripes-docker/files/Dockerfile
@@ -1,5 +1,0 @@
-FROM nginx:stable-alpine
-
-COPY output /usr/share/nginx/html
-COPY yarn.lock *install.json /usr/share/nginx/html/
-COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/roles/stripes-docker/handlers/main.yml
+++ b/roles/stripes-docker/handlers/main.yml
@@ -16,21 +16,21 @@
   become: yes
   docker_service:
     project_name: stripes
-    definition: 
+    definition:
       version: '2'
-      services: 
+      services:
         stripes:
           build: "{{ stripes_conf_dir }}"
           image: stripes
-          ports: 
-            - "{{ stripes_host_address }}:{{ stripes_port }}:80"
-          networks:  
+          ports:
+            - "{{ stripes_host_address }}:{{ stripes_listen_port }}:{{ stripes_listen_port }}"
+          networks:
             stripes-net:
               aliases:
                 - stripes-serv
           restart: always
-      networks: 
-        stripes-net: 
+      networks:
+        stripes-net:
           external: true
     state: present
   register: stripes_container_status

--- a/roles/stripes-docker/tasks/main.yml
+++ b/roles/stripes-docker/tasks/main.yml
@@ -27,12 +27,12 @@
 - name: copy certificate and key to docker build dir
   become: yes
   copy:
-    src: {{ item }}
-    dest: "{{ stripes_conf_dir }}/{{ item }}"
+    src: "{{ item }}"
+    dest: "{{ stripes_conf_dir }}/{{ item|basename }}"
   with_items:
-    - {{ stripes_certificate_file }}
-    - {{ stripes_certificate_key_file }}
-  when: {{ stripes_enable_https }}
+    - "{{ stripes_certificate_file }}"
+    - "{{ stripes_certificate_key_file }}"
+  when: stripes_enable_https == true
 
 - name: copy Dockerfile to docker build dir
   become: yes

--- a/roles/stripes-docker/tasks/main.yml
+++ b/roles/stripes-docker/tasks/main.yml
@@ -24,17 +24,27 @@
   when: top_down_install|default(false)
   ignore_errors: yes
 
-- name: copy Dockerfile to docker build dir
+- name: copy certificate and key to docker build dir
   become: yes
   copy:
-    src: Dockerfile
+    src: {{ item }}
+    dest: "{{ stripes_conf_dir }}/{{ item }}"
+  with_items:
+    - {{ stripes_certificate_file }}
+    - {{ stripes_certificate_key_file }}
+  when: {{ stripes_enable_https }}
+
+- name: copy Dockerfile to docker build dir
+  become: yes
+  template:
+    src: Dockerfile.j2
     dest: "{{ stripes_conf_dir }}/Dockerfile"
   notify: Rebuild container
 
 - name: copy build-run to build dir
   become: yes
-  copy:
-    src: build-run
+  template:
+    src: build-run.j2
     dest: "{{ stripes_conf_dir }}/build-run"
     mode: 0755
   notify: Rebuild container

--- a/roles/stripes-docker/templates/Dockerfile.j2
+++ b/roles/stripes-docker/templates/Dockerfile.j2
@@ -1,8 +1,8 @@
 FROM nginx:stable-alpine
 
 {%if stripes_enable_https %}
-COPY --chown nginx:nginx {{ stripes_certificate_file }} /etc/nginx/ssl/{{ stripes_certificate_file }}
-COPY --chown nginx:nginx {{ stripes_certificate_key_file }} /etc/nginx/ssl/{{ stripes_certificate_key_file }}
+COPY --chown nginx:nginx {{ stripes_certificate_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_file|basename }}
+COPY --chown nginx:nginx {{ stripes_certificate_key_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_key_file|basename }}
 {% endif %}
 COPY output /usr/share/nginx/html
 COPY yarn.lock *install.json /usr/share/nginx/html/

--- a/roles/stripes-docker/templates/Dockerfile.j2
+++ b/roles/stripes-docker/templates/Dockerfile.j2
@@ -1,0 +1,9 @@
+FROM nginx:stable-alpine
+
+{%if stripes_enable_https %}
+COPY --chown nginx:nginx {{ stripes_certificate_file }} /etc/nginx/ssl/{{ stripes_certificate_file }}
+COPY --chown nginx:nginx {{ stripes_certificate_key_file }} /etc/nginx/ssl/{{ stripes_certificate_key_file }}
+{% endif %}
+COPY output /usr/share/nginx/html
+COPY yarn.lock *install.json /usr/share/nginx/html/
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/roles/stripes-docker/templates/Dockerfile.j2
+++ b/roles/stripes-docker/templates/Dockerfile.j2
@@ -1,8 +1,8 @@
 FROM nginx:stable-alpine
 
 {%if stripes_enable_https %}
-COPY --chown nginx:nginx {{ stripes_certificate_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_file|basename }}
-COPY --chown nginx:nginx {{ stripes_certificate_key_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_key_file|basename }}
+COPY --chown=nginx:nginx {{ stripes_certificate_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_file|basename }}
+COPY --chown=nginx:nginx {{ stripes_certificate_key_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_key_file|basename }}
 {% endif %}
 COPY output /usr/share/nginx/html
 COPY yarn.lock *install.json /usr/share/nginx/html/

--- a/roles/stripes-docker/templates/build-run.j2
+++ b/roles/stripes-docker/templates/build-run.j2
@@ -7,4 +7,4 @@ docker rmi stripes
 sudo docker build -t stripes:latest /etc/folio/stripes
 docker run -d --name stripes_stripes_1 --network stripes-net \
   --network-alias stripes-serv --restart=always \
-  -p=0.0.0.0:3000:80 stripes
+  -p=0.0.0.0:{{ stripes_listen_port }}:{{ stripes_listen_port }} stripes

--- a/roles/stripes-docker/templates/nginx.conf.j2
+++ b/roles/stripes-docker/templates/nginx.conf.j2
@@ -5,9 +5,8 @@ server {
   gzip on;
   gzip_types  text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
   {%if stripes_enable_https %}
-  ssl on;
-  ssl_certificate {{ stripes_certificate_file|basename }}
-  ssl_certificate_key {{ stripes_certificate_key_file|basename }}
+  ssl_certificate ssl/{{ stripes_certificate_file|basename }};
+  ssl_certificate_key ssl/{{ stripes_certificate_key_file|basename }};
   {% endif %}
   # Serve index.html for any request not found
   location / {

--- a/roles/stripes-docker/templates/nginx.conf.j2
+++ b/roles/stripes-docker/templates/nginx.conf.j2
@@ -6,8 +6,8 @@ server {
   gzip_types  text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
   {%if stripes_enable_https %}
   ssl on;
-  ssl_certificate {{ stripes_certificate_file }}
-  ssl_certificate_key {{ stripes_certificate_key_file }}
+  ssl_certificate {{ stripes_certificate_file|basename }}
+  ssl_certificate_key {{ stripes_certificate_key_file|basename }}
   {% endif %}
   # Serve index.html for any request not found
   location / {

--- a/roles/stripes-docker/templates/nginx.conf.j2
+++ b/roles/stripes-docker/templates/nginx.conf.j2
@@ -1,9 +1,14 @@
 server {
-  listen 80;
-  server_name {{ nginx_servername }};
+  listen {{ stripes_listen_port }}{%if stripes_enable_https %} ssl{% endif %};
+  server_name {{ nginx_servername }}{% for alias in stripes_server_name %} {{ alias }}{% endfor %};
   charset utf-8;
-  gzip on; 
+  gzip on;
   gzip_types  text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
+  {%if stripes_enable_https %}
+  ssl on;
+  ssl_certificate {{ stripes_certificate_file }}
+  ssl_certificate_key {{ stripes_certificate_key_file }}
+  {% endif %}
   # Serve index.html for any request not found
   location / {
     # Set path
@@ -14,4 +19,10 @@ server {
     }
     try_files $uri /index.html;
   }
+  {% if nginx_proxy_okapi %}
+  location /okapi {
+    rewrite ^/okapi/(.*) /$1 break;
+    proxy_pass {{ nginx_proxy_okapi_url }};
+  }
+  {% endif %}
 }

--- a/roles/stripes-docker/templates/nginx.conf.j2
+++ b/roles/stripes-docker/templates/nginx.conf.j2
@@ -20,6 +20,7 @@ server {
   }
   {% if nginx_proxy_okapi %}
   location /okapi {
+    client_max_body_size {{ nginx_proxy_upload_max_size }};
     rewrite ^/okapi/(.*) /$1 break;
     proxy_pass {{ nginx_proxy_okapi_url }};
   }

--- a/roles/stripes-nginx/README.md
+++ b/roles/stripes-nginx/README.md
@@ -5,6 +5,8 @@ Ansible role to serve a stripes webpack with nginx (and optionally proxy Okapi).
 ## Notes
 
 * If proxying Okapi, `stripes_okapi_url` for the `stripes-build` role must be set to this server (`http[s]://server_name[:listen_port]/okapi`).
+* If proxying, nginx must be configured to handle large data imports. This can be set with nginx_proxy_upload_max_size
+* to enable https, you have to enable proxying and provide the path to the certificate and key files
 
 ## Prerequisites
 
@@ -16,10 +18,14 @@ Ansible role to serve a stripes webpack with nginx (and optionally proxy Okapi).
 ```yaml
 # defaults
 stripes_listen_port: 80
+stripes_enable_https: false
+stripes_certificate_file: null
+stripes_certificate_key_file: null
 stripes_server_name:
   - "{{ ansible_default_ipv4.address }}"
 nginx_proxy_okapi: no
 nginx_proxy_okapi_url: "http://{{ ansible_default_ipv4.address }}:9130"
+nginx_proxy_upload_max_size: 100M
 ```
 
 ## TODO

--- a/roles/stripes-nginx/defaults/main.yml
+++ b/roles/stripes-nginx/defaults/main.yml
@@ -7,3 +7,4 @@ stripes_server_name:
   -  "{{ ansible_default_ipv4.address }}"
 nginx_proxy_okapi: no
 nginx_proxy_okapi_url: "http://{{ ansible_default_ipv4.address }}:9130"
+nginx_proxy_upload_max_size: 100M

--- a/roles/stripes-nginx/defaults/main.yml
+++ b/roles/stripes-nginx/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 stripes_listen_port: 80
+stripes_enable_https: false
+stripes_certificate_file: null
+stripes_certificate_key_file: null
 stripes_server_name:
   -  "{{ ansible_default_ipv4.address }}"
 nginx_proxy_okapi: no

--- a/roles/stripes-nginx/tasks/main.yml
+++ b/roles/stripes-nginx/tasks/main.yml
@@ -21,19 +21,19 @@
     mode: 700
     owner: nginx
     state: directory
-  when: {{ stripes_enable_https }}
+  when: stripes_enable_https == true
 
 - name: copy certificate and key to nginx config dir
   become: yes
   copy:
-    src: {{ item }}
-    dest: "/etc/nginx/ssl/{{ item }}"
+    src: "{{ item }}"
+    dest: "/etc/nginx/ssl/{{ item|basename }}"
     mode: 500
     owner: nginx
   with_items:
-    - {{ stripes_certificate_file }}
-    - {{ stripes_certificate_key_file }}
-  when: {{ stripes_enable_https }}
+    - "{{ stripes_certificate_file }}"
+    - "{{ stripes_certificate_key_file }}"
+  when: stripes_enable_https == true
 
 
 

--- a/roles/stripes-nginx/tasks/main.yml
+++ b/roles/stripes-nginx/tasks/main.yml
@@ -14,6 +14,29 @@
   stat: path=/etc/folio/okapi/install.json
   register: stat_install_json
 
+- name: create nginx ssl dir
+  become: yes
+  file:
+    dest: /etc/nginx/ssl
+    mode: 700
+    owner: nginx
+    state: directory
+  when: {{ stripes_enable_https }}
+
+- name: copy certificate and key to nginx config dir
+  become: yes
+  copy:
+    src: {{ item }}
+    dest: "/etc/nginx/ssl/{{ item }}"
+    mode: 500
+    owner: nginx
+  with_items:
+    - {{ stripes_certificate_file }}
+    - {{ stripes_certificate_key_file }}
+  when: {{ stripes_enable_https }}
+
+
+
 - name: Install stripes configuration for nginx
   become: yes
   template: src=stripes.conf.j2 dest=/etc/nginx/sites-available/stripes

--- a/roles/stripes-nginx/templates/stripes.conf.j2
+++ b/roles/stripes-nginx/templates/stripes.conf.j2
@@ -5,9 +5,8 @@ server {
   gzip on;
   gzip_types  text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
   {%if stripes_enable_https %}
-  ssl on;
-  ssl_certificate {{ stripes_certificate_file|basename }}
-  ssl_certificate_key {{ stripes_certificate_key_file|basename }}
+  ssl_certificate ssl/{{ stripes_certificate_file|basename }};
+  ssl_certificate_key ssl/{{ stripes_certificate_key_file|basename }};
   {% endif %}
   # Serve index.html for any request not found
   location / {

--- a/roles/stripes-nginx/templates/stripes.conf.j2
+++ b/roles/stripes-nginx/templates/stripes.conf.j2
@@ -1,7 +1,14 @@
 server {
-  listen {{ stripes_listen_port }};
+  listen {{ stripes_listen_port }}{%if stripes_enable_https %} ssl{% endif %};
   server_name{% for alias in stripes_server_name %} {{ alias }}{% endfor %};
   charset utf-8;
+  gzip on;
+  gzip_types  text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
+  {%if stripes_enable_https %}
+  ssl on;
+  ssl_certificate {{ stripes_certificate_file }}
+  ssl_certificate_key {{ stripes_certificate_key_file }}
+  {% endif %}
   # Serve index.html for any request not found
   location / {
     # Set path

--- a/roles/stripes-nginx/templates/stripes.conf.j2
+++ b/roles/stripes-nginx/templates/stripes.conf.j2
@@ -6,8 +6,8 @@ server {
   gzip_types  text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
   {%if stripes_enable_https %}
   ssl on;
-  ssl_certificate {{ stripes_certificate_file }}
-  ssl_certificate_key {{ stripes_certificate_key_file }}
+  ssl_certificate {{ stripes_certificate_file|basename }}
+  ssl_certificate_key {{ stripes_certificate_key_file|basename }}
   {% endif %}
   # Serve index.html for any request not found
   location / {

--- a/roles/stripes-nginx/templates/stripes.conf.j2
+++ b/roles/stripes-nginx/templates/stripes.conf.j2
@@ -32,6 +32,7 @@ server {
   {% endif %}
   {% if nginx_proxy_okapi %}
   location /okapi {
+    client_max_body_size {{ nginx_proxy_upload_max_size }};
     rewrite ^/okapi/(.*) /$1 break;
     proxy_pass {{ nginx_proxy_okapi_url }};
   }


### PR DESCRIPTION
This patch enables the automatic configuration of https for folio using the stripes docker image (testes) and the nginx installation method (to be tested). Also extended some documentation and the folio playbook to include securing the supertenant.

