### PR TITLE
roles/common: Avoid removing ansible user from other user groups

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Add ansible user to folio group
   become: yes
-  user: name={{ ansible_user }} groups={{ folio_group }}
+  user: name={{ ansible_user }} groups={{ folio_group }} append=yes
 
 - name: Install prerequisites from apt
   become: yes


### PR DESCRIPTION
roles/common has a task for adding ansible user into folio user group.

Adding ansible user to folio group causes the ansible user to be removed from any other groups that they are in. This is due to the fact that we are missing a parameter "append". It defaults to "no" [1]. We should set "append=yes" to avoid unexpected behavior.

Particularly the ansible user gets kicked out of "sudo" group and if you run it again, the tasks will fail because of insufficient permissions.

[1] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-append