### PR TITLE
FOLIO-2949: Add mod-data-export to snapshot-core and testing-core config

### DIFF
--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -54,6 +54,16 @@ folio_modules:
       - { name: loadSample, value: "true" }
     deploy: yes
 
+  - name: mod-data-export
+    deploy: yes
+    docker_env:
+      - name: AWS_ACCESS_KEY_ID
+        value: "{{ data_export_aws_id | default('') }}"
+      - name: AWS_SECRET_ACCESS_KEY
+        value: "{{ data_export_aws_secret | default('') }}"
+      - name: JAVA_OPTIONS
+        value: "-XX:MaxRAMPercentage=66.0 -Dbucket.name={{ data_export_bucket_name | default('') }}"
+
   - name: mod-email
     deploy: yes
 

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -135,9 +135,6 @@ folio_modules:
       - { name: loadSample, value: "true" }
     deploy: yes
 
-  - name: mod-remote-storage
-    deploy: yes
-
 # Variables for building UI
 stripes_github_project: https://github.com/folio-org/platform-core
 stripes_github_version: snapshot

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -97,6 +97,16 @@ folio_modules:
   - name: mod-inventory
     deploy: yes
 
+  - name: mod-data-export
+    deploy: yes
+    docker_env:
+      - name: AWS_ACCESS_KEY_ID
+        value: "{{ data_export_aws_id | default('') }}"
+      - name: AWS_SECRET_ACCESS_KEY
+        value: "{{ data_export_aws_secret | default('') }}"
+      - name: JAVA_OPTIONS
+        value: "-XX:MaxRAMPercentage=66.0 -Dbucket.name={{ data_export_bucket_name | default('') }}"
+
   - name: mod-feesfines
     tenant_parameters:
       - { name: loadReference, value: "true" }
@@ -123,6 +133,9 @@ folio_modules:
   - name: mod-tags
     tenant_parameters:
       - { name: loadSample, value: "true" }
+    deploy: yes
+
+  - name: mod-remote-storage
     deploy: yes
 
 # Variables for building UI


### PR DESCRIPTION
data-export interface is now required by ui-inventory.