### PR TITLE
Remove mod-marccat FOLIO-2952

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -172,9 +172,6 @@ folio_modules:
   - name: mod-login-saml
     deploy: yes
 
-  - name: mod-marccat
-    deploy: yes
-
   - name: mod-ncip
     deploy: yes
 

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -154,9 +154,6 @@ folio_modules:
   - name: mod-kb-ebsco-java
     deploy: yes
 
-  - name: mod-marccat
-    deploy: yes
-
   - name: mod-ncip
     deploy: yes
 


### PR DESCRIPTION
The mod-marccat and ui-marccat are to be deprecated. [FOLIO-2952](https://issues.folio.org/browse/FOLIO-2952) and [FOLIO-2953](https://issues.folio.org/browse/FOLIO-2953).