### PR TITLE
STRIPES-639 provide sourcemaps for snapshot, snapshot-core

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -266,6 +266,7 @@ stripes_github_project: https://github.com/folio-org/platform-complete
 stripes_github_version: snapshot
 folio_npm_repo: npm-folioci
 platform_remove_lock: false
+with_sourcemap: true
 node_environment:
   NODE_ENV: production
 

--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -159,6 +159,7 @@ stripes_github_project: https://github.com/folio-org/platform-core
 stripes_github_version: snapshot
 folio_npm_repo: npm-folioci
 platform_remove_lock: false
+with_sourcemap: true
 node_environment:
   NODE_ENV: production
 


### PR DESCRIPTION
A long-ago issue with a transitive dependency caused a build failure
when sourcemaps were enabled. Much has changed since June, 2019, when
this was filed and this issue cannot be reproduced locally.

Refs [STRIPES-639](https://issues.folio.org/browse/STRIPES-639)