### PR TITLE
FOLIO-3038 remove mutable when creating perms

### DIFF
--- a/doc/ansible-variables.md
+++ b/doc/ansible-variables.md
@@ -69,12 +69,12 @@ admin_permissions:
 
 # Permissions not defined in backend module descriptors
 additional_permissions:
-  - { permissionName: module.trivial.enabled, displayName: "UI: Trivial module is enabled", subPermissions: "[]", mutable: "false" }
-  - { permissionName: module.users.enabled, displayName: "UI: Users module is enabled", subPermissions: "[]", mutable: "false" }
-  - { permissionName: module.items.enabled, displayName: "UI: Items module is enabled", subPermissions: "[]", mutable: "false" }
-  - { permissionName: module.scan.enabled, displayName: "UI: Scan module is enabled", subPermissions: "[]", mutable: "false" }
-  - { permissionName: module.okapi-console.enabled, displayName: "UI: Okapi Console module is enabled", subPermissions: "[]", mutable: "false" }
-  - { permissionName: module.organization.enabled, displayName: "UI: Organization module is enabled", subPermissions: "[]", mutable: "false" }
+  - { permissionName: module.trivial.enabled, displayName: "UI: Trivial module is enabled", subPermissions: "[]" }
+  - { permissionName: module.users.enabled, displayName: "UI: Users module is enabled", subPermissions: "[]" }
+  - { permissionName: module.items.enabled, displayName: "UI: Items module is enabled", subPermissions: "[]" }
+  - { permissionName: module.scan.enabled, displayName: "UI: Scan module is enabled", subPermissions: "[]" }
+  - { permissionName: module.okapi-console.enabled, displayName: "UI: Okapi Console module is enabled", subPermissions: "[]" }
+  - { permissionName: module.organization.enabled, displayName: "UI: Organization module is enabled", subPermissions: "[]" }
 
 mod_auth_users:
   - username: auth_test1

--- a/roles/deprecated/mod-auth-data/tasks/main.yml
+++ b/roles/deprecated/mod-auth-data/tasks/main.yml
@@ -95,7 +95,6 @@
         'permissionName' : '{{ item.permissionName }}',
         'displayName' : '{{ item.displayName }}',
         'subPermissions' : {{ item.subPermissions }},
-        'mutable' : {{ item.mutable }},
         'visible' : {{ item.visible|default(false) }}
       }
     status_code: 201,422


### PR DESCRIPTION
## Purpose
Make adjustments needed to conform to the new permissions interface 6.0 (mutable can no longer be specified when creating permissions)

See https://issues.folio.org/browse/FOLIO-3038
See also:  https://github.com/folio-org/mod-permissions/pull/115 and https://issues.folio.org/browse/MODPERMS-126
