### PR TITLE
Increase Okapi deploy timeout for snapshot and testing builds

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -11,6 +11,9 @@ folio_install_type: single_server
 okapi_java_opts:
   - "-Ddeploy.waitIterations=90"
 
+# used in okapi-tenant-deploy
+deploy_timeout: 1200
+
 # proxy edge modules - folio-elb
 include_edge_elb: true
 

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -18,6 +18,7 @@ okapi_java_opts:
 
 # used in okapi-tenant-deploy
 update_launch_descr: true
+deploy_timeout: 1200
 
 # proxy edge modules - folio-elb
 include_edge_elb: true


### PR DESCRIPTION
Apparently 15 minutes is not enough; increasing to 20 minutes. Towards FOLIO-3091