### PR TITLE
FOLIO-3134: pubsub user

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -245,6 +245,10 @@ folio_modules:
     docker_env:
       - name: OKAPI_URL
         value: "{{ okapi_url }}"
+      - name: SYSTEM_USER_NAME
+        value: pubsub-user
+      - name: SYSTEM_USER_PASSWORD
+        value: pubsub2021
 
   - name: mod-quick-marc
     deploy: yes

--- a/group_vars/snapshot-core
+++ b/group_vars/snapshot-core
@@ -113,6 +113,10 @@ folio_modules:
     docker_env:
       - name: OKAPI_URL
         value: "{{ okapi_url }}"
+      - name: SYSTEM_USER_NAME
+        value: pubsub-user
+      - name: SYSTEM_USER_PASSWORD
+        value: pubsub2021
 
   - name: mod-password-validator
     deploy: yes

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -54,6 +54,10 @@ folio_modules:
     docker_env:
       - name: OKAPI_URL
         value: "{{ okapi_url }}"
+      - name: SYSTEM_USER_NAME
+        value: pubsub-user
+      - name: SYSTEM_USER_PASSWORD
+        value: pubsub2021
 
   - name: mod-configuration
     tenant_parameters:

--- a/group_vars/testing-core
+++ b/group_vars/testing-core
@@ -49,6 +49,10 @@ folio_modules:
     docker_env:
       - name: OKAPI_URL
         value: "{{ okapi_url }}"
+      - name: SYSTEM_USER_NAME
+        value: pubsub-user
+      - name: SYSTEM_USER_PASSWORD
+        value: pubsub2021
 
   - name: mod-configuration
     tenant_parameters:


### PR DESCRIPTION
With [MODPUBSUB-78](https://issues.folio.org/browse/MODPUBSUB-78) mod-pubsub now supports creating a FOLIO system user with a password based on environment variables available to the container. This PR updates the reference build configuration files to use that feature.