### PR TITLE
Add support for edge_http_version in edge-module role.

### DIFF
--- a/roles/edge-module/README.md
+++ b/roles/edge-module/README.md
@@ -86,6 +86,9 @@ inst_user:
 # Proxy through nginx
 edge_nginx_proxy: yes
 
+# HTTP version produced by module, default 1.0
+# edge_http_version: 1.1
+
 # Module setup
 # edge_module, and edge_module_publish_port variables must be defined or the role will fail
 # edge_module_path must be defined if proxying through nginx

--- a/roles/edge-module/defaults/main.yml
+++ b/roles/edge-module/defaults/main.yml
@@ -34,6 +34,9 @@ inst_user_perms: [ ]
 # Proxy through nginx
 edge_nginx_proxy: yes
 
+# HTTP version produced by module, default 1.0
+# edge_http_version: 1.1
+
 # Module setup
 # edge_module, and edge_module_publish_port variables must be defined or the role will fail
 # edge_module_path must be defined if proxying through nginx

--- a/roles/edge-module/tasks/main.yml
+++ b/roles/edge-module/tasks/main.yml
@@ -206,6 +206,9 @@
     block: |
       location {{ item }} {
         proxy_pass http://localhost:{{ edge_module_publish_port }};
+      {% if edge_http_version|default(false) %}
+        proxy_http_version {{ edge_http_version }};
+      {% endif %}
       }
   notify: Restart nginx
   loop: "{{ edge_module_path_working }}"


### PR DESCRIPTION
Allows nginx to proxy edge modules that use HTTP 1.1 (nginx default is 1.0). Towards FOLIO-3159.