### PR TITLE
Remove folio-cron jobs (age-to-lost) from Vagrant builds.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,9 @@ Vagrant.configure(2) do |config|
     snapshot_backend_core.vm.box = "folio/snapshot-backend-core"
     snapshot_backend_core.vm.network "forwarded_port", guest: 9130, host: 9130
     snapshot_backend_core.vm.network "forwarded_port", guest: 8000, host: 8130
+    snapshot_backend_core.vm.provision "ansible" do |ansible|
+      ansible.playbook = "test.yml"
+    end
   end
 
   config.vm.define "testing", autostart: false do |testing|

--- a/folio.yml
+++ b/folio.yml
@@ -171,11 +171,6 @@
       permissions:
         - okapi.all
 
-- name: Set up folioCronService
-  hosts: snapshot-core:testing-core:testing:snapshot
-  roles:
-    - cron-jobs
-
 # Set up stripes
 - name: Build stripes webpack, assign permissions
   hosts: stripes-build


### PR DESCRIPTION
Towards FOLIO-3176