### PR TITLE
Set Kafka environment variables for mod-search (and other Kafka modules)

### DIFF
--- a/group_vars/release
+++ b/group_vars/release
@@ -45,7 +45,7 @@ folio_modules:
 
   - name: mod-data-export-worker
     deploy: yes
-    docker_env: 
+    docker_env:
       - name: AWS_ACCESS_KEY_ID
         value: "{{ data_export_aws_id | default('minioadmin') }}"
       - name: AWS_SECRET_ACCESS_KEY
@@ -72,6 +72,8 @@ folio_modules:
         value: "{{ okapi_url }}"
       - name: JAVA_OPTIONS
         value: "-XX:MaxRAMPercentage=66.0"
+      - name: KAFKA_EVENTS_CONSUMER_PATTERN
+        value: "FOLIO\.(.*\.)inventory\.(instance|holdings-record|item)"
 
   - name: mod-source-record-storage
     deploy: yes
@@ -87,7 +89,7 @@ okapi_register_modules: no
 okapi_enable_modules: no
 platform_remove_lock: no
 with_sourcemap: no
-node_environment: 
+node_environment:
    NODE_ENV: production
 
 # Jobs for folioCronService

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -275,6 +275,8 @@ folio_modules:
         value: "{{ okapi_url }}"
       - name: JAVA_OPTIONS
         value: "-XX:MaxRAMPercentage=66.0"
+      - name: KAFKA_EVENTS_CONSUMER_PATTERN
+        value: "FOLIO\.(.*\.)inventory\.(instance|holdings-record|item)"
 
   - name: mod-sender
     deploy: yes

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -248,6 +248,8 @@ folio_modules:
         value: "{{ okapi_url }}"
       - name: JAVA_OPTIONS
         value: "-XX:MaxRAMPercentage=66.0"
+      - name: KAFKA_EVENTS_CONSUMER_PATTERN
+        value: "FOLIO\.(.*\.)inventory\.(instance|holdings-record|item)"
 
   - name: mod-service-interaction
     deploy: yes

--- a/roles/okapi-deployment/README.md
+++ b/roles/okapi-deployment/README.md
@@ -65,7 +65,7 @@ module_env:
   - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
   - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
   - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
-  - { name: ENV, value: "{{ kafka_topic_env }}"
+  - { name: ENV, value: "{{ kafka_topic_env }}" }
   - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
   - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 

--- a/roles/okapi-deployment/README.md
+++ b/roles/okapi-deployment/README.md
@@ -35,15 +35,25 @@ Invoke the role in a playbook, e.g.:
 ```yaml
 ---
 # defaults
-
 # Database setup
 create_db: yes
 pg_admin_user: folio_admin
 pg_admin_password: folio_admin
 pg_host: "{{ ansible_default_ipv4.address }}"
 pg_port: 5432
+pg_maint_db: postgres
 pg_max_pool_size: 5
 module_database: okapi_modules
+
+# Kafka setup
+kafka_host: "{{ ansible_default_ipv4.address }}"
+kafka_port: 9092
+kafka_topic_env: "FOLIO"
+
+# Elasticsearch setup
+elasticsearch_host: "{{ ansible_default_ipv4.address }}"
+elasticsearch_port: 9301
+
 # If the module_env list is populated, it will set global module environment variables
 # These environment variables can be overridden by the docker_env property of the folio_modules entries
 module_env:
@@ -53,6 +63,11 @@ module_env:
   - { name: DB_USERNAME, value: "{{ pg_admin_user }}" }
   - { name: DB_PASSWORD, value: "{{ pg_admin_password }}" }
   - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
+  - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
+  - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
+  - { name: ENV, value: "{{ kafka_topic_env }}"
+  - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
+  - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 
 # Okapi setup
 okapi_port: 9130

--- a/roles/okapi-deployment/defaults/main.yml
+++ b/roles/okapi-deployment/defaults/main.yml
@@ -30,7 +30,7 @@ module_env:
   - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
   - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
   - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
-  - { name: ENV, value: "{{ kafka_topic_env }}"
+  - { name: ENV, value: "{{ kafka_topic_env }}" }
   - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
   - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 

--- a/roles/okapi-deployment/defaults/main.yml
+++ b/roles/okapi-deployment/defaults/main.yml
@@ -13,6 +13,7 @@ module_database: okapi_modules
 # Kafka setup
 kafka_host: "{{ ansible_default_ipv4.address }}"
 kafka_port: 9092
+kafka_topic_env: "FOLIO"
 
 # Elasticsearch setup
 elasticsearch_host: "{{ ansible_default_ipv4.address }}"
@@ -29,6 +30,7 @@ module_env:
   - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
   - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
   - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
+  - { name: ENV, value: "{{ kafka_topic_env }}"
   - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
   - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 

--- a/roles/okapi-tenant-deploy/README.md
+++ b/roles/okapi-tenant-deploy/README.md
@@ -72,7 +72,7 @@ module_env:
   - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
   - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
   - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
-  - { name: ENV, value: "{{ kafka_topic_env }}"
+  - { name: ENV, value: "{{ kafka_topic_env }}" }
   - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
   - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 

--- a/roles/okapi-tenant-deploy/README.md
+++ b/roles/okapi-tenant-deploy/README.md
@@ -50,20 +50,37 @@ pg_admin_user: folio_admin
 pg_admin_password: folio_admin
 pg_host: "{{ ansible_default_ipv4.address }}"
 pg_port: 5432
+pg_maint_db: postgres
 pg_max_pool_size: 5
 module_database: okapi_modules
+
+# Kafka setup
+kafka_host: "{{ ansible_default_ipv4.address }}"
+kafka_port: 9092
+kafka_topic_env: "FOLIO"
+
+# Elasticsearch setup
+elasticsearch_host: "{{ ansible_default_ipv4.address }}"
+elasticsearch_port: 9301
+
 module_env:
-  - { name: db.host, value: "{{ pg_host }}" }
-  - { name: db.port, value: "{{ pg_port }}" }
-  - { name: db.database, value: "{{ module_database }}" }
-  - { name: db.username, value: "{{ pg_admin_user }}" }
-  - { name: db.password, value: "{{ pg_admin_password }}" }
-  - { name: db.maxPoolSize, value: "{{ pg_max_pool_size }}" }
+  - { name: DB_HOST, value: "{{ pg_host }}" }
+  - { name: DB_PORT, value: "{{ pg_port }}" }
+  - { name: DB_DATABASE, value: "{{ module_database }}" }
+  - { name: DB_USERNAME, value: "{{ pg_admin_user }}" }
+  - { name: DB_PASSWORD, value: "{{ pg_admin_password }}" }
+  - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
+  - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
+  - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
+  - { name: ENV, value: "{{ kafka_topic_env }}"
+  - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
+  - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 
 # If the module_env list is populated, it will set global module environment variables
 # These environment variables can be overridden by the docker_env property of the folio_modules entries
 
 # Okapi setup
+folio_install_type: single_server
 folio_modules: []
 okapi_port: 9130
 okapi_url: "http://{{ ansible_default_ipv4.address }}:{{ okapi_port }}"

--- a/roles/okapi-tenant-deploy/defaults/main.yml
+++ b/roles/okapi-tenant-deploy/defaults/main.yml
@@ -29,7 +29,7 @@ module_env:
   - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
   - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
   - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
-  - { name: ENV, value: "{{ kafka_topic_env }}"
+  - { name: ENV, value: "{{ kafka_topic_env }}" }
   - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
   - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 

--- a/roles/okapi-tenant-deploy/defaults/main.yml
+++ b/roles/okapi-tenant-deploy/defaults/main.yml
@@ -14,6 +14,7 @@ module_database: okapi_modules
 # Kafka setup
 kafka_host: "{{ ansible_default_ipv4.address }}"
 kafka_port: 9092
+kafka_topic_env: "FOLIO"
 
 # Elasticsearch setup
 elasticsearch_host: "{{ ansible_default_ipv4.address }}"
@@ -28,6 +29,7 @@ module_env:
   - { name: DB_MAXPOOLSIZE, value: "{{ pg_max_pool_size }}" }
   - { name: KAFKA_HOST, value: "{{ kafka_host }}" }
   - { name: KAFKA_PORT, value: "{{ kafka_port }}" }
+  - { name: ENV, value: "{{ kafka_topic_env }}"
   - { name: ELASTICSEARCH_HOST, value: "{{ elasticsearch_host }}" }
   - { name: ELASTICSEARCH_PORT, value: "{{ elasticsearch_port }}" }
 


### PR DESCRIPTION
* Set the `ENV` environment variable in the okapi-deployment and okapi-tenant-deploy roles globally, for all Kafka-reliant modules.
* Set the `KAFKA_EVENTS_CONSUMER_PATTERN` environment variable for the mod-search container.