### PR TITLE
remove obsolete mod-ldp vars

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -183,11 +183,6 @@ folio_modules:
 
   - name: mod-ldp
     deploy: yes
-    docker_env:
-      - name: SPRING_DATASOURCE_PASSWORD
-        value: "{{ ldp_password }}"
-      - name: SPRING_DATASOURCE_URL
-        value: "jdbc:postgresql://{{ pg_host }}/ldp"
 
   - name: mod-licenses
     deploy: yes


### PR DESCRIPTION
env vars, SPRING_DATASOURCE_PASSWORD and SPRING_DATASOURCE_URL, should no longer be set for mod-ldp. 