### PR TITLE
Increase deploy_timeout for okapi-tenant-deploy for testing/testing-backend builds.

### DIFF
--- a/group_vars/testing
+++ b/group_vars/testing
@@ -22,7 +22,7 @@ okapi_java_opts:
 
 # used in okapi-tenant-deploy
 update_launch_descr: true
-deploy_timeout: 1200
+deploy_timeout: 1800
 
 # proxy edge modules - folio-elb
 include_edge_elb: true


### PR DESCRIPTION
Towards FOLIO-3336