### PR TITLE
Grant tenant admin user perms.users.assign.okapi

### DIFF
--- a/roles/create-tenant-admin/README.md
+++ b/roles/create-tenant-admin/README.md
@@ -27,7 +27,7 @@ Invoke the role in a playbook, optionally with variables defined, e.g.:
 
 ## Notes
 
-The behavior of this role depends on the variable `perms_users_assign`. If that variable is true, the user is given the extra permissions `perms.users.assign.immutable` and `perms.users.assign.mutable` for compatibility with versions of mod-permissions later than v5.15.0-SNAPSHOT.121. Otherwise, the default behavior is to give the user only the `perms.all` permission.
+The behavior of this role depends on the variable `perms_users_assign`. If that variable is true, the user is given the extra permissions `perms.users.assign.immutable`, `perms.users.assign.mutable`, and `perms.users.assign.okapi` for compatibility with versions of mod-permissions later than v5.15.0-SNAPSHOT.121. Otherwise, the default behavior is to give the user only the `perms.all` permission.
 
 ## Variables
 

--- a/roles/create-tenant-admin/tasks/main.yml
+++ b/roles/create-tenant-admin/tasks/main.yml
@@ -124,6 +124,7 @@
           {% if perms_users_assign %}
               "perms.users.assign.immutable",
               "perms.users.assign.mutable",
+              "perms.users.assign.okapi"
           {% endif %}
               "perms.all"
             ]

--- a/roles/create-tenant-admin/tasks/main.yml
+++ b/roles/create-tenant-admin/tasks/main.yml
@@ -124,7 +124,7 @@
           {% if perms_users_assign %}
               "perms.users.assign.immutable",
               "perms.users.assign.mutable",
-              "perms.users.assign.okapi"
+              "perms.users.assign.okapi",
           {% endif %}
               "perms.all"
             ]


### PR DESCRIPTION
Allows extra tenant admin to be created for Vagrant boxes (see [FOLIO-2841](https://issues.folio.org/browse/FOLIO-2841)).