### PR TITLE
Refactor vagrant-tidy role for better performance.

### DIFF
--- a/roles/okapi-docker-container/tasks/main.yml
+++ b/roles/okapi-docker-container/tasks/main.yml
@@ -32,6 +32,8 @@
     command: "dev -conf okapi/okapi.json"
     env:
       JAVA_OPTIONS: "-Djava.awt.headless=true{% for option in okapi_java_opts %} {{ option }}{% endfor %}"
+    labels:
+      service: okapi
   register: okapi_create_container
 
 - meta: flush_handlers

--- a/roles/vagrant-tidy/files/vagrant-tidy.sh
+++ b/roles/vagrant-tidy/files/vagrant-tidy.sh
@@ -1,32 +1,10 @@
 #!/bin/bash
-# cat - << EOWARNING
 # WARNING: This script will fill up your left over disk space.
 
 # DO NOT RUN THIS WHEN YOUR VIRTUAL HD IS RAW!!!!!!
 
 # You should NOT do this on a running system.
 # This is purely for making vagrant boxes damn small.
-
-# Press Ctrl+C within the next 10 seconds if you want to abort!!
-
-# EOWARNING
-# sleep 10;
-
-# Remove APT cache
-apt-get clean -y
-apt-get autoclean -y
-
-# Zero free space to aid VM compression
-dd if=/dev/zero of=/EMPTY bs=1M
-rm -f /EMPTY
-
-# Remove bash history
-unset HISTFILE
-rm -f /root/.bash_history
-rm -f /home/vagrant/.bash_history
-
-# Cleanup log files
-find /var/log -type f | while read f; do echo -ne '' > $f; done;
 
 # Whiteout root
 count=`df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}'`;
@@ -40,10 +18,8 @@ let count--
 dd if=/dev/zero of=/boot/whitespace bs=1024 count=$count;
 rm /boot/whitespace;
 
-# Whiteout swap, update fstab
-swappart=`cat /proc/swaps | tail -n1 | awk -F ' ' '{print $1}'`
-swapoff $swappart;
-dd if=/dev/zero of=$swappart;
-mkswap $swappart;
-swapon $swappart;
-sed -i.bak -r '/swap\s+sw/s|^UUID\=\w+\-\w+\-\w+\-\w+\-\w+|'$swappart'|' /etc/fstab;
+# Zero free space to aid VM compression
+dd if=/dev/zero of=/EMPTY bs=1M 2>/dev/null
+sync
+rm -f /EMPTY
+sync

--- a/roles/vagrant-tidy/tasks/main.yml
+++ b/roles/vagrant-tidy/tasks/main.yml
@@ -1,19 +1,21 @@
 ---
 # Role to tidy up a Vagrant box for packaging
-# Note that vagrant-tidy.sh destroys all free disk space!
-- name: Copy vagrant-tidy.sh to /root
+- name: Stop okapi container
   become: yes
-  copy: src=vagrant-tidy.sh dest=/root/vagrant-tidy.sh mode=0700
+  docker_container:
+    name: okapi
+    state: stopped
+
+- name: Prune containers for backend modules
+  become: yes
+  command: "/usr/bin/docker system prune -f --volumes --filter label!=service"
 
 - name: Stop services
   become: yes
   service: name={{ item }} state=stopped
   with_items:
-    - okapi-deploy
-    - okapi
     - docker
     - postgresql
-  ignore_errors: yes
 
 # packer sticks this in here?
 - name: Remove guest additions ISO, if there
@@ -27,6 +29,52 @@
   file:
     path: "~/.docker"
     state: absent
+
+- name: Clean up stripes build directory node_modules
+  become: yes
+  file:
+    path: "{{ stripes_conf_dir|default('/etc/folio/stripes') }}/node_modules"
+    state: absent
+
+- name: Clean up stripes build directory output
+  become: yes
+  file:
+    path: "{{ stripes_conf_dir|default('/etc/folio/stripes') }}/output"
+    state: absent
+
+- name: Clean out yarn cache
+  become: yes
+  command: "/usr/bin/yarn cache clean --all"
+  ignore_errors: yes
+
+- name: Remove root bash history
+  become: yes
+  file:
+    path: /root/.bash_history
+    state: absent
+
+- name: Remove vagrant bash history
+  file:
+    path: /home/vagrant/.bash_history
+    state: absent
+
+- name: apt autoremove
+  become: yes
+  apt: autoremove=yes
+
+- name: Clear out apt cache
+  become: yes
+  command: /usr/bin/apt-get clean -y
+
+- name: Clean up log files
+  become: yes
+  shell:
+    cmd: "find /var/log -type f | while read f; do echo -ne '' > $f; done;"
+
+# Note that vagrant-tidy.sh destroys all free disk space!
+- name: Copy vagrant-tidy.sh to /root
+  become: yes
+  copy: src=vagrant-tidy.sh dest=/root/vagrant-tidy.sh mode=0700
 
 - name: Run vagrant-tidy.sh
   become: yes


### PR DESCRIPTION
Also add label to Okapi container so it can be marked to retain when doing `docker system prune`. Towards FOLIO-3369.