### PR TITLE
Set default for perms_users_assign to false in create-tenant-admin role.

### DIFF
--- a/roles/create-tenant-admin/tasks/main.yml
+++ b/roles/create-tenant-admin/tasks/main.yml
@@ -121,7 +121,7 @@
           {
             "userId": "{{ admin_user_id }}",
             "permissions": [
-          {% if perms_users_assign %}
+          {% if perms_users_assign|default(false) %}
               "perms.users.assign.immutable",
               "perms.users.assign.mutable",
               "perms.users.assign.okapi",


### PR DESCRIPTION
Avoid error if variable is not defined.