### PR TITLE
FOLIO-3394 suppress edit of users

### DIFF
--- a/roles/post-config-entries/README.md
+++ b/roles/post-config-entries/README.md
@@ -27,3 +27,9 @@ admin_user:
   username: diku_admin
   password: admin
 ```
+
+In addition to the default config entries, when 'do_suppress_edit' is set to 'True' and a
+list of users is defined in 'suppress_edit_userlist',  the list of users are configured so 
+that they cannot be edited via the Stripes UI (@folio/users). 
+
+

--- a/roles/post-config-entries/defaults/main.yml
+++ b/roles/post-config-entries/defaults/main.yml
@@ -20,3 +20,11 @@ tenant: diku
 admin_user:
   username: diku_admin
   password: admin
+
+# Set to 'True' to enable suppression of user edits
+do_suppress_edit: False
+
+# If 'do-suppress-edit' is set, suppress edit of tenant admin by default
+suppress_edit_userlist: 
+  - "{{ admin_user.username }}"
+

--- a/roles/post-config-entries/tasks/main.yml
+++ b/roles/post-config-entries/tasks/main.yml
@@ -75,7 +75,7 @@
           X-Okapi-Tenant: "{{ tenant }}"
           Accept: application/json
           X-Okapi-Token: "{{ tenant_token | default('') }}"
-        body: "{{ lookup('template', 'suppress-edit.json.j2') }}"
+        body: "{{ lookup('template', 'suppress_edit.json.j2') }}"
         status_code: 201, 422
   when: do_suppress_edit 
 

--- a/roles/post-config-entries/tasks/main.yml
+++ b/roles/post-config-entries/tasks/main.yml
@@ -53,17 +53,9 @@
         uuid_list="{{ uuid_list|default([]) + [ item.json.users[0].id ] }}"
       loop: "{{ user_list.results }}"
 
-    - name: debug uuid_list
-      ansible.builtin.debug:
-        msg: "{{ uuid_list }}"
-
     - name: concat list to string
       set_fact: 
         uuids="{{ uuid_list | join('\\", \\"') }}" 
-  
-    - name: debug uuids
-      ansible.builtin.debug:
-        msg: "{{ uuids }}"
  
     - name: POST suppress-edit configuration
       uri: 

--- a/roles/post-config-entries/tasks/main.yml
+++ b/roles/post-config-entries/tasks/main.yml
@@ -33,3 +33,49 @@
     body: "{{ lookup('template', item) }}" 
     status_code: 201, 422
   with_items: "{{ config_entry_list }}"
+
+- name: Configure suppress-edit users
+  block: 
+    - name: get user uuids 
+      uri: 
+        url: "{{ okapi_url }}/users?query=username%3d%3d{{ item }}"
+        headers: 
+          Authtoken-Refresh-Cache: "true"
+          Accept: "application/json, text/plain"
+          X-Okapi-Tenant: "{{ tenant }}"
+          X-Okapi-Token: "{{ tenant_token | default('') }}"
+        status_code: 200
+      loop: "{{ suppress_edit_userlist }}"   
+      register: user_list  
+
+    - name: set fact uuids
+      set_fact: 
+        uuid_list="{{ uuid_list|default([]) + [ item.json.users[0].id ] }}"
+      loop: "{{ user_list.results }}"
+
+    - name: debug uuid_list
+      ansible.builtin.debug:
+        msg: "{{ uuid_list }}"
+
+    - name: concat list to string
+      set_fact: 
+        uuids="{{ uuid_list | join('\\", \\"') }}" 
+  
+    - name: debug uuids
+      ansible.builtin.debug:
+        msg: "{{ uuids }}"
+ 
+    - name: POST suppress-edit configuration
+      uri: 
+        url: "{{ okapi_url }}/configurations/entries"
+        method: POST
+        body_format: json
+        headers: 
+          Authtoken-Refresh-Cache: "true"
+          X-Okapi-Tenant: "{{ tenant }}"
+          Accept: application/json
+          X-Okapi-Token: "{{ tenant_token | default('') }}"
+        body: "{{ lookup('template', 'suppress-edit.json.j2') }}"
+        status_code: 201, 422
+  when: do_suppress_edit 
+

--- a/roles/post-config-entries/tasks/main.yml
+++ b/roles/post-config-entries/tasks/main.yml
@@ -69,5 +69,6 @@
           X-Okapi-Token: "{{ tenant_token | default('') }}"
         body: "{{ lookup('template', 'suppress_edit.json.j2') }}"
         status_code: 201, 422
+      when: uuid_list|length > 0 
   when: do_suppress_edit 
 

--- a/roles/post-config-entries/templates/suppress_edit.json.j2
+++ b/roles/post-config-entries/templates/suppress_edit.json.j2
@@ -1,0 +1,7 @@
+{
+  "module": "@folio/users",
+  "configName": "suppressEdit",
+  "default": true,
+  "enabled": true,
+  "value": "[\"{{ uuids }}\"]"
+}


### PR DESCRIPTION
Implementation of feature added in https://issues.folio.org/browse/UIU-2499.    Modification of the post-config-entries role to optionally include a list of users that cannot be edited via the Stripes Users app.  