### PR TITLE
FOLIO-3523: Fix Out-of-bounds Read in folio-ansible stripes Dockerfile

### DIFF
--- a/roles/stripes-docker/templates/Dockerfile.j2
+++ b/roles/stripes-docker/templates/Dockerfile.j2
@@ -1,5 +1,7 @@
 FROM nginx:stable-alpine
 
+RUN apk --no-cache upgrade
+
 {%if stripes_enable_https %}
 COPY --chown=nginx:nginx {{ stripes_certificate_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_file|basename }}
 COPY --chown=nginx:nginx {{ stripes_certificate_key_file|basename }} /etc/nginx/ssl/{{ stripes_certificate_key_file|basename }}


### PR DESCRIPTION
nginx:stable-alpine in https://github.com/folio-org/folio-ansible/blob/master/roles/stripes-docker/templates/Dockerfile.j2 contains

pcre2/pcre2@10.39-r0

that has Out-of-bounds Read vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2022-1586
* https://nvd.nist.gov/vuln/detail/CVE-2022-1587

A fix is available:

pcre2/pcre2@10.40-r0

However, nginx:stable-alpine doesn't immediately get security fixes: https://github.com/nginxinc/docker-nginx/issues/671

Therefore RUN apk --no-cache upgrade is needed.