### PR TITLE
FOLIO-3612 Remove three mod-codex from group_vars/snapshot

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -38,8 +38,6 @@ add_modules:
   - edge-rtac
   - edge-inn-reach
   # MISSING: edge-sip2
-  - mod-codex-inventory
-  - mod-codex-ekb
   - mod-data-import-converter-storage
   - mod-data-export-spring
   - mod-data-export-worker
@@ -95,15 +93,6 @@ folio_modules:
     tenant_parameters:
       - { name: loadReference, value: "true" }
       - { name: loadSample, value: "true" }
-    deploy: yes
-
-  - name: mod-codex-ekb
-    deploy: yes
-
-  - name: mod-codex-inventory
-    deploy: yes
-
-  - name: mod-codex-mux
     deploy: yes
 
   - name: mod-configuration


### PR DESCRIPTION
[FOLIO-3612](https://issues.folio.org/browse/FOLIO-3612)
Already removed from platform-complete