### PR TITLE
Add entry for mod-serials-management to folio_modules variable in snapshot config.

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -333,6 +333,9 @@ folio_modules:
   - name: mod-sender
     deploy: yes
 
+  - name: mod-serials-management
+    deploy: yes
+
   - name: mod-service-interaction
     deploy: yes
 


### PR DESCRIPTION
Apparently this is _still_ necessary for the Vagrant build. FOLIO-3624.