### PR TITLE
FOLIO-3683 MODDICONV-259 Rename mod-data-import-converter-storage mod-di-converter-storage

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -39,7 +39,7 @@ add_modules:
   - edge-inn-reach
   # MISSING: edge-sip2
   - mod-bulk-operations
-  - mod-data-import-converter-storage
+  - mod-di-converter-storage
   - mod-data-export-spring
   - mod-data-export-worker
   - mod-ebsconet
@@ -160,7 +160,7 @@ folio_modules:
   - name: mod-data-import
     deploy: yes
 
-  - name: mod-data-import-converter-storage
+  - name: mod-di-converter-storage
     deploy: yes
 
   - name: mod-ebsconet


### PR DESCRIPTION
[MODDICONV-259](https://issues.folio.org/browse/MODDICONV-259)
[FOLIO-3683](https://issues.folio.org/browse/FOLIO-3683)

The new [ModuleDescriptor](https://github.com/folio-org/mod-di-converter-storage/blob/master/descriptors/ModuleDescriptor-template.json) utilises the "replace" facility, and retains the same interface name and version.