### PR TITLE
Add OKAPI_URL to mod-consortia

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -128,6 +128,9 @@ folio_modules:
 
   - name: mod-consortia
     deploy: yes
+    docker_env:
+      - name: OKAPI_URL
+        value: "{{ okapi_url }}"
 
   - name: mod-courses
     deploy: yes


### PR DESCRIPTION
In scope of [MODCON-43](https://issues.folio.org/browse/MODCON-43) new [environment variable](https://github.com/folio-org/mod-consortia/pull/44/files#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d:~:text=okapi%3A-,url%3A%20%24%7BOKAPI_URL%3Ahttp%3A//okapi%3A9130%7D,-kafka%3A) was created to get OKAPI_URL 