### PR TITLE
FOLIO-3894: Set INNREACH_TENANTS=testTenant|diku for mod-inn-reach

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -250,6 +250,9 @@ folio_modules:
     deploy: yes
 
   - name: mod-inn-reach
+    docker_env:
+      - name: INNREACH_TENANTS
+        value: "testTenant|diku"
     deploy: yes
 
   - name: mod-inventory


### PR DESCRIPTION
https://issues.folio.org/browse/MODINREACH-381 introduced a new required environment variable.

If not set the module fails at startup. Therefore the snapshot environment build fails: https://jenkins-aws.indexdata.com/job/Automation/job/build-platform-complete-snapshot/20934/