### PR TITLE
FOLIO-3897: Adding OKAPI_URL to mod-inn-reach and mod-remote-storage

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -259,6 +259,8 @@ folio_modules:
     docker_env:
       - name: INNREACH_TENANTS
         value: "testTenant|diku"
+      - name: OKAPI_URL
+        value: "{{ okapi_url }}"
     deploy: yes
 
   - name: mod-inventory
@@ -404,6 +406,8 @@ folio_modules:
     docker_env:
       - name: SYSTEM_USER_PASSWORD
         value: system-user
+      - name: OKAPI_URL
+        value: "{{ okapi_url }}"
 
   - name: mod-rtac
     deploy: yes


### PR DESCRIPTION
These two modules need the `OKAPI_URL` environment variable in order to work properly. This is part of the RTR work.

https://issues.folio.org/browse/FOLIO-3897