### PR TITLE
Create databases with und-x-icu sort order for Unicode characters

### DIFF
--- a/roles/create-database/defaults/main.yml
+++ b/roles/create-database/defaults/main.yml
@@ -7,6 +7,10 @@ pg_port: 5432
 pg_maint_db: postgres
 db_admin_user: folio_module_admin
 db_admin_password: folio_module_admin
+db_encoding: UTF-8
+db_lc_collate: und-x-icu
+db_lc_ctype: und-x-icu
+db_template: template0
 database_name: okapi_modules
 folio_install_type: single_server
 rds: false

--- a/roles/create-database/tasks/main.yml
+++ b/roles/create-database/tasks/main.yml
@@ -50,3 +50,7 @@
     login_password: "{{ pg_admin_password }}"
     name: "{{ database_name }}"
     owner: "{{ db_admin_user }}"
+    encoding: "{{ db_encoding }}"
+    lc_collate: "{{ db_lc_collate }}"
+    lc_ctype: "{{ db_lc_ctype }}"
+    template: "{{ db_template }}"


### PR DESCRIPTION
If databases are created with UTF-8 and und-x-icu sorting then postgres sorts non-ASCII characters in a reasonable language-agnostic order: https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-PREDEFINED-ICU-UND-X-ICU
This has been in use at https://folio-demo.gbv.de/ for several years and works much better than the default byte number based sorting.