### PR TITLE
FOLIO-3901: invalid locale "und-x-icu" platform-complete-snapshot

### DIFF
--- a/roles/create-database/defaults/main.yml
+++ b/roles/create-database/defaults/main.yml
@@ -7,10 +7,6 @@ pg_port: 5432
 pg_maint_db: postgres
 db_admin_user: folio_module_admin
 db_admin_password: folio_module_admin
-db_encoding: UTF-8
-db_lc_collate: und-x-icu
-db_lc_ctype: und-x-icu
-db_template: template0
 database_name: okapi_modules
 folio_install_type: single_server
 rds: false

--- a/roles/create-database/tasks/main.yml
+++ b/roles/create-database/tasks/main.yml
@@ -50,7 +50,3 @@
     login_password: "{{ pg_admin_password }}"
     name: "{{ database_name }}"
     owner: "{{ db_admin_user }}"
-    encoding: "{{ db_encoding }}"
-    lc_collate: "{{ db_lc_collate }}"
-    lc_ctype: "{{ db_lc_ctype }}"
-    template: "{{ db_template }}"


### PR DESCRIPTION
https://issues.folio.org/browse/FOLIO-3901

Revert "Create databases with und-x-icu sort order for Unicode characters" This reverts commit b92fa3013c751c47e69350625480ff0a29152554.