### PR TITLE
FOLIO-3921: Make snapshot environments run in "enhanced security mode" and remove LOGIN_COOKIE_SAMESITE

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -94,6 +94,9 @@ folio_modules:
 
   - name: mod-authtoken
     deploy: yes
+    docker_env:
+      - name: LEGACY_TOKEN_TENANTS
+        value: ""
 
   - name: mod-bulk-operations
     deploy: yes
@@ -326,9 +329,15 @@ folio_modules:
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes
+    docker_env:
+      - name: LOGIN_COOKIE_SAMESITE
+        value: "None"
 
   - name: mod-login-saml
     deploy: yes
+    docker_env:
+      - name: LOGIN_COOKIE_SAMESITE
+        value: "None"
 
   - name: mod-ncip
     deploy: yes

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -97,6 +97,8 @@ folio_modules:
     docker_env:
       - name: LEGACY_TOKEN_TENANTS
         value: ""
+      - name: JAVA_OPTIONS
+        value: "-XX:MaxRAMPercentage=66.0 -Dcache.permissions=true -Dallow.cross.tenant.requests=true"
 
   - name: mod-bulk-operations
     deploy: yes
@@ -347,20 +349,9 @@ folio_modules:
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes
-    docker_env:
-    docker_env:
-      - name: JAVA_OPTIONS
-        value: "-XX:MaxRAMPercentage=66.0"
-      - name: LOGIN_COOKIE_SAMESITE
-        value: "None"
 
   - name: mod-login-saml
     deploy: yes
-    docker_env:
-      - name: JAVA_OPTIONS
-        value: "-XX:MaxRAMPercentage=66.0"
-      - name: LOGIN_COOKIE_SAMESITE
-        value: "None"
 
   - name: mod-ncip
     deploy: yes


### PR DESCRIPTION
https://issues.folio.org/browse/FOLIO-3921

Not sure if this will be disruptive to people but I think the sooner we do this the more prepared we will be for removing the legacy endpoints.

Also adding removing the LOGIN_COOKIE_SAMESITE variable from mod-login and mod-login-saml which will cause the default value of Lax to be used.