### PR TITLE
FOLIO-3921: Revert make snapshot environments run in "enhanced secur…

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -94,11 +94,6 @@ folio_modules:
 
   - name: mod-authtoken
     deploy: yes
-    docker_env:
-      - name: LEGACY_TOKEN_TENANTS
-        value: ""
-      - name: JAVA_OPTIONS
-        value: "-XX:MaxRAMPercentage=66.0 -Dcache.permissions=true -Dallow.cross.tenant.requests=true"
 
   - name: mod-bulk-operations
     deploy: yes
@@ -349,9 +344,19 @@ folio_modules:
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes
+    docker_env:
+      - name: JAVA_OPTIONS
+        value: "-XX:MaxRAMPercentage=66.0"
+      - name: LOGIN_COOKIE_SAMESITE
+        value: "None"
 
   - name: mod-login-saml
     deploy: yes
+    docker_env:
+      - name: JAVA_OPTIONS
+        value: "-XX:MaxRAMPercentage=66.0"
+      - name: LOGIN_COOKIE_SAMESITE
+        value: "None"
 
   - name: mod-ncip
     deploy: yes


### PR DESCRIPTION
This reverts https://github.com/folio-org/folio-ansible/pull/574. Thanks @wafschneider pointing this out and from saving me from completely breaking the reference envs.

I will create another PR to remove `LOGIN_COOKIE_SAMESITE` which we still want to do.