### PR TITLE
FOLIO-3921: Remove LOGIN_COOKIE_SAMESITE

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -344,19 +344,9 @@ folio_modules:
     tenant_parameters:
       - { name: loadSample, value: "true" }
     deploy: yes
-    docker_env:
-      - name: JAVA_OPTIONS
-        value: "-XX:MaxRAMPercentage=66.0"
-      - name: LOGIN_COOKIE_SAMESITE
-        value: "None"
 
   - name: mod-login-saml
     deploy: yes
-    docker_env:
-      - name: JAVA_OPTIONS
-        value: "-XX:MaxRAMPercentage=66.0"
-      - name: LOGIN_COOKIE_SAMESITE
-        value: "None"
 
   - name: mod-ncip
     deploy: yes


### PR DESCRIPTION
Please see description and comments in the ticket: https://issues.folio.org/browse/FOLIO-3921. Originally two things were included in this ticket, and a PR was made for it, but then it turned out that one of them needed to be removed. That was reverted, and this PR covers the change that we still need.

See:
* https://github.com/folio-org/folio-ansible/pull/574
* https://github.com/folio-org/folio-ansible/pull/575
