### PR TITLE
FOLIO-3957 - pin Docker CE to version 24

### DIFF
--- a/roles/docker-engine/defaults/main.yml
+++ b/roles/docker-engine/defaults/main.yml
@@ -4,6 +4,9 @@ docker_users:
 
 folioci: false
 
+# Unpinning this will cause an API error with older versions of docker-compose
+docker_version: "5:24.0.7-1~ubuntu.20.04~focal"
+
 # no default for these, if undefined use unauthenticated sessions to
 # Docker Hub for image pulls
 # docker_image_repo:

--- a/roles/docker-engine/tasks/main.yml
+++ b/roles/docker-engine/tasks/main.yml
@@ -41,8 +41,8 @@
   become: yes
   apt:
     name:
-      - docker-ce
-      - docker-ce-cli
+      - docker-ce={{ docker_version }}
+      - docker-ce-cli={{ docker_version }}
       - containerd.io
 
 - name: Create /etc/docker


### PR DESCRIPTION
Kafka deployment fails due to incompatible API versions between Docker engine and Docker Compose. It appears the version of Docker engine went from v24 to v25 in the last 12 hours or so on Focal. Docker Compose which is installed as a Python Pip package is really old and incompatible with version 25 of Docker engine. Attempts to upgrade docker-compose via Pip, however, fails with all kinds of Python errors and actually breaks Pip when upgrading to the latest version. Rather than go down this rabbit hole of Ansible and Python dependencies, I'm going to pin Docker engine version at 24 for now in the docker-engine folio-ansible role.