### PR TITLE
FOLIO-3957 pin Docker CE to version 24 - morning-glory refenv

### DIFF
--- a/roles/docker-engine/defaults/main.yml
+++ b/roles/docker-engine/defaults/main.yml
@@ -4,6 +4,9 @@ docker_users:
 
 folioci: false
 
+# Unpinning this will cause an API error with older versions of docker-compose
+docker_version: "5:24.0.7-1~ubuntu.20.04~focal"
+
 # no default for these, if undefined use unauthenticated sessions to
 # Docker Hub for image pulls
 # docker_image_repo:

--- a/roles/docker-engine/tasks/main.yml
+++ b/roles/docker-engine/tasks/main.yml
@@ -41,8 +41,8 @@
   become: yes
   apt:
     name:
-      - docker-ce
-      - docker-ce-cli
+      - docker-ce={{ docker_version }}
+      - docker-ce-cli={{ docker_version }}
       - containerd.io
 
 - name: Create /etc/docker


### PR DESCRIPTION
Same workaround as for master branch #584