### PR TITLE
Update folio-registry FQDN hostname

### DIFF
--- a/roles/okapi-pull/defaults/main.yml
+++ b/roles/okapi-pull/defaults/main.yml
@@ -3,5 +3,5 @@ okapi_port: 9130
 okapi_url: "http://{{ ansible_default_ipv4.address }}:{{ okapi_port }}"
 mod_descr_repos:
   urls:
-    - http://folio-registry.aws.indexdata.com
+    - http://folio-registry.dev.folio.org
 okapi_pull_timeout: 300


### PR DESCRIPTION
was folio-registry.aws.indexdata.com
now folio-registry.dev.folio.org