### PR TITLE
FOLIO-4001: Create MinIO bucket for mod-lists in Vagrant build

### DIFF
--- a/folio.yml
+++ b/folio.yml
@@ -26,8 +26,10 @@
 # Additional infrastructure for platform-complete builds
 - hosts: testing:snapshot:release
   roles:
-    - minio-docker # for mod-data-export-worker
-    - elasticsearch # for mod-search
+    - role: minio-docker # for multiple modules
+      minio_buckets:
+        - "{{ lists_app_bucket_name | default('lists-app-bucket') }}" # mod-lists requires the bucket to be created ahead of time
+    - role: elasticsearch # for mod-search
 
 # Configure builds
 # Need to build the webpack early to allow enough RAM for the build
@@ -57,13 +59,14 @@
 - name: Configure snapshot build
   hosts: snapshot
   pre_tasks:
-    - name: set data export, mod-oai-pmh, mod-entities-links, mod-marc-migrations, and erm AWS URLs for minio
+    - name: set AWS URLs for minio
       set_fact:
         data_export_aws_url: "http://{{ ansible_default_ipv4.address }}:{{ minio_port|default('9000') }}"
         erm_aws_url: "http://{{ ansible_default_ipv4.address }}:{{ minio_port|default('9000') }}"
         oai_pmh_aws_url: "http://{{ ansible_default_ipv4.address }}:{{ minio_port|default('9000') }}"
         mod_elinks_aws_url: "http://{{ ansible_default_ipv4.address }}:{{ minio_port|default('9000') }}"
         mod_marc_migrations_aws_url: "http://{{ ansible_default_ipv4.address }}:{{ minio_port|default('9000') }}"
+        lists_app_aws_url: "http://{{ ansible_default_ipv4.address }}:{{ minio_port|default('9000') }}"
   roles:
     - role: stripes-build
       okapi_register_modules: false

--- a/roles/minio-docker/README.md
+++ b/roles/minio-docker/README.md
@@ -19,4 +19,7 @@ minio_data_path: /data # path to data directory, see below
 # Local mounts. Can be combined with minio_data_path above to persist minio storage
 # minio_volumes:
 #   - "/usr/local/shared/minio-data:{{ minio_data_path }}"
+# Buckets to create on initialization
+# minio_buckets:
+#   - "{{ lists_app_bucket_name | default('lists-app-bucket') }}"
 ```

--- a/roles/minio-docker/defaults/main.yml
+++ b/roles/minio-docker/defaults/main.yml
@@ -8,3 +8,6 @@ minio_data_path: /data # path to data directory, see below
 # Local mounts. Can be combined with minio_data_path above to persist minio storage
 # minio_volumes:
 #   - "/usr/local/shared/minio-data:{{ minio_data_path }}"
+# Buckets to create on initialization
+# minio_buckets:
+#   - "{{ lists_app_bucket_name | default('lists-app-bucket') }}"

--- a/roles/minio-docker/tasks/main.yml
+++ b/roles/minio-docker/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
+# HERE I AM Try uninstalling boto3/botocore, install from PIP instead.
 # Role to launch MinIO container
+- name: Install prereqs from pip
+  become: yes
+  pip:
+    name:
+      - boto3
+      - botocore
+
 - name: Launch MinIO container
   become: yes
   docker_container:
@@ -11,3 +19,12 @@
     command: "server {{ minio_data_path }}"
     state: started
     restart_policy: always
+
+- name: Create buckets
+  s3_bucket:
+    name: "{{ item }}"
+    access_key: minioadmin
+    secret_key: minioadmin
+    s3_url: "http://{{ ansible_default_ipv4.address }}:{{ minio_port|default('9000') }}"
+    state: present
+  loop: "{{ minio_buckets | default([]) }}"


### PR DESCRIPTION
Also add feature to minio-docker role to allow for creation of buckets when the container is created.