### PR TITLE
FOLIO-4029 Use platform-complete snapshot branch for building the folio-snapshot Vagrant box.

### DIFF
--- a/folio.yml
+++ b/folio.yml
@@ -74,7 +74,8 @@
     - okapi-pull
     - tenant-data
     - role: build-module-list
-      stripes_platform: /etc/folio/stripes
+      deploy_url: "https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/okapi-install.json"
+      enable_url: "https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/stripes-install.json"
     - okapi-deployment
     - role: okapi-tenant-deploy
       create_db: no


### PR DESCRIPTION
With the addition of the Keycloak-enabled modules to the FOLIO module descriptor registry, the Vagrant box build fails trying to resolve dependencies.

It actually doesn't really need to do that, since that job is done by the build-platform-complete-snapshot job. This change removes the tasks that build out the full dependency tree and instead just uses the install files from platform-complete (as does the folio-snapshot hosted reference build job).