### PR TITLE
FOLIO-4029 Remove dependency checking for mod-authtoken in create-tenant-admin (release-r1-2023)

### DIFF
--- a/roles/create-tenant-admin/README.md
+++ b/roles/create-tenant-admin/README.md
@@ -27,7 +27,9 @@ Invoke the role in a playbook, optionally with variables defined, e.g.:
 
 ## Notes
 
-The behavior of this role depends on the variable `perms_users_assign`. If that variable is true, the user is given the extra permissions `perms.users.assign.immutable`, `perms.users.assign.mutable`, and `perms.users.assign.okapi` for compatibility with versions of mod-permissions later than v5.15.0-SNAPSHOT.121. Otherwise, the default behavior is to give the user only the `perms.all` permission.
+* mod-authtoken is disabled and reenabled **without dependency checking**. That means while this role is running, modules that depend on the authtoken interface may throw errors.
+
+* The behavior of this role depends on the variable `perms_users_assign`. If that variable is true, the user is given the extra permissions `perms.users.assign.immutable`, `perms.users.assign.mutable`, and `perms.users.assign.okapi` for compatibility with versions of mod-permissions later than v5.15.0-SNAPSHOT.121. Otherwise, the default behavior is to give the user only the `perms.all` permission.
 
 ## Variables
 

--- a/roles/create-tenant-admin/tasks/main.yml
+++ b/roles/create-tenant-admin/tasks/main.yml
@@ -25,9 +25,9 @@
       Accept: "application/json, text/plain"
   register: authtoken_module
 
-- name: Disable authtoken and dependencies
+- name: Disable authtoken without dependency checking
   uri:
-    url: "{{ okapi_url }}/_/proxy/tenants/{{ tenant }}/install"
+    url: "{{ okapi_url }}/_/proxy/tenants/{{ tenant }}/install?depCheck=false"
     method: POST
     body_format: json
     headers:
@@ -184,21 +184,15 @@
     ####################
     # Enable authtoken #
     ####################
-    - name: Build authtoken_enable list
-      set_fact:
-        authtoken_enable: "{{ authtoken_enable|default([]) + [ { 'id': item.id, 'action': 'enable' } ] }}"
-      when: authtoken_module.json.0 is defined
-      with_items: "{{ authtoken_disable.json|reverse|list }}"
-
-    - name: Enable authtoken and dependencies
+    - name: Enable authtoken
       uri:
-        url: "{{ okapi_url }}/_/proxy/tenants/{{ tenant }}/install"
+        url: "{{ okapi_url }}/_/proxy/tenants/{{ tenant }}/install?depCheck=false"
         method: POST
         body_format: json
         headers:
           X-Okapi-Tenant: "supertenant"
           X-Okapi-Token: "{{ supertenant_token | default('') }}"
           Accept: "application/json, text/plain"
-        body: "{{ authtoken_enable }}"
+        body: '[ { "id": "{{ authtoken_module.json.0.id }}", "action": "enable" } ]'
       register: authtoken_enable_result
       when: authtoken_module.json.0 is defined


### PR DESCRIPTION
Prevents errors in disabling the module when multiple products offer the authtoken interface. FOLIO-4029.

Same change as on master, but for branch `release-r1-2023` Orchid