### PR TITLE
FOLIO-4029: Use Okapi 5.3.0 for environment build

### DIFF
--- a/group_vars/release
+++ b/group_vars/release
@@ -5,8 +5,8 @@ enable_okapi: true
 folio_install_type: single_server
 minio_port: 9500
 
-deploy_url: https://raw.githubusercontent.com/folio-org/platform-complete/R1-2023/okapi-install.json
-enable_url: https://raw.githubusercontent.com/folio-org/platform-complete/R1-2023/stripes-install.json
+deploy_url: https://raw.githubusercontent.com/folio-org/platform-complete/FOLIO-4029-orchid/okapi-install.json
+enable_url: https://raw.githubusercontent.com/folio-org/platform-complete/FOLIO-4029-orchid/stripes-install.json
 
 # pin Node.js to supported version
 nodejs_version: v16

--- a/group_vars/release
+++ b/group_vars/release
@@ -5,8 +5,8 @@ enable_okapi: true
 folio_install_type: single_server
 minio_port: 9500
 
-deploy_url: https://raw.githubusercontent.com/folio-org/platform-complete/FOLIO-4029-orchid/okapi-install.json
-enable_url: https://raw.githubusercontent.com/folio-org/platform-complete/FOLIO-4029-orchid/stripes-install.json
+deploy_url: https://raw.githubusercontent.com/folio-org/platform-complete/R1-2023/okapi-install.json
+enable_url: https://raw.githubusercontent.com/folio-org/platform-complete/R1-2023/stripes-install.json
 
 # pin Node.js to supported version
 nodejs_version: v16

--- a/group_vars/release
+++ b/group_vars/release
@@ -15,7 +15,7 @@ nodejs_version: v16
 perms_users_assign: true
 
 update_launch_descr: true
-okapi_version: 5.0.1
+okapi_version: 5.3.0
 okapi_docker_org: folioorg
 okapi_java_opts:
   - "-Ddeploy.waitIterations=90"


### PR DESCRIPTION
The Orchid reference environment build now requires adding the `depCheck=false` parameter to the create-admin role (see PR #608). This parameter is only supported in Okapi v5.3.0 or higher.