### PR TITLE
MODAT-168: Perms rename auth.signtoken auth.signrefreshtoken

### DIFF
--- a/roles/okapi-secure/tasks/main.yml
+++ b/roles/okapi-secure/tasks/main.yml
@@ -115,7 +115,7 @@
 
 - name: Set permissions_list
   set_fact:
-    permissions_list: '{% if perms_users_assign %}"perms.users.assign.immutable","perms.users.assign.mutable","perms.users.assign.okapi",{% endif %}"perms.all","okapi.all","okapi.proxy.pull.modules.post","login.all","users.all","auth.signtoken","auth.signrefreshtoken"'
+    permissions_list: '{% if perms_users_assign %}"perms.users.assign.immutable","perms.users.assign.mutable","perms.users.assign.okapi",{% endif %}"perms.all","okapi.all","okapi.proxy.pull.modules.post","login.all","users.all","auth.sign-and-refresh-token.all"'
 
 - name: add permissions for superuser on supertenant
   uri:


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODAT-168

Replace renamed permissions ´auth.signtoken´ and `auth.signrefreshtoken` with `auth.sign-and-refresh-token.all`.

To be merged at the same time as https://github.com/folio-org/mod-authtoken/pull/167