### PR TITLE
MODBULKOPS-454 - Enable support of system user for mod-bulk-operations

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -123,6 +123,12 @@ folio_modules:
         value: "{{ data_export_bucket_name | default('data-export-bucket') }}"
       - name: S3_IS_AWS
         value: "{{ data_export_local_aws | default('false') }}"
+      - name: OKAPI_URL
+        value: "{{ okapi_url }}"
+      - name: SYSTEM_USER_NAME
+        value: "mod-bulk-operations-system-user"
+      - name: SYSTEM_USER_PASSWORD
+        value: "mod-bulk-operations-system-user"
 
   - name: mod-calendar
     deploy: yes


### PR DESCRIPTION
It is necessary to enable variables:
**OKAPI_URL,
SYSTEM_USER_NAME,
SYSTEM_USER_PASSWORD,**
 to support the system user in the mod-bulk-operations module.