### PR TITLE
build: update MaxRAMPercentage to 85% for mod-agreements

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -83,7 +83,7 @@ folio_modules:
     deploy: yes
     docker_env:
       - name: JAVA_OPTIONS
-        value: "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=67.0 -XX:+PrintFlagsFinal"
+        value: "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=85.0 -XX:+PrintFlagsFinal"
       - name: AWS_ACCESS_KEY_ID
         value: "{{ erm_aws_id | default('minioadmin') }}"
       - name: GLOBAL_S3_SECRET_KEY


### PR DESCRIPTION
mod-agreements is experiencing OOMs, there are investigations underway to mitigate this issue as a bug, but in the meantime we need to unblock snapshot env for QA/dev work, and we believe this will provide the necessary extra RAM to avoid OOMs


Update is in tandem with PR in mod-agreements: https://github.com/folio-org/mod-agreements/pull/864