### PR TITLE
Revert Agreements change to memory requirements

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -83,7 +83,7 @@ folio_modules:
     deploy: yes
     docker_env:
       - name: JAVA_OPTIONS
-        value: "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=85.0 -XX:+PrintFlagsFinal"
+        value: "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=67.0 -XX:+PrintFlagsFinal"
       - name: AWS_ACCESS_KEY_ID
         value: "{{ erm_aws_id | default('minioadmin') }}"
       - name: GLOBAL_S3_SECRET_KEY


### PR DESCRIPTION
With time taken to investigate the issue [(comment on this agreements PR)](https://github.com/folio-org/mod-agreements/pull/867#issue-2913284073) it seems that there is no short term alternative but to increase the memory requirements.

As mentioned by @dcrossleyau, that belongs on the individual MD for mod-agreements (hence the PR there) and so this PR reverts the change made [in this PR to folio-ansible](https://github.com/folio-org/folio-ansible/pull/624)