### PR TITLE
feat: Include ENDPOINTS_INCLUDE_STACK_TRACE=true for mod-agreements

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -96,6 +96,8 @@ folio_modules:
         value: "{{ erm_bucket_name | default('erm-bucket') }}"
       - name: DB_MAXPOOLSIZE
         value: "20"
+      - name: ENDPOINTS_INCLUDE_STACK_TRACE
+        value: "true"
 
   - name: mod-audit
     deploy: yes


### PR DESCRIPTION
On snapshot we wish to act as if we are in a "development" environment with respect to stacktraces in responses, allowing us to debug issues in hosted ref systems more efficiently.

refs ERM-3292