### PR TITLE
omit ui-tenant-settings.settings.locale permission from diku_admin

### DIFF
--- a/roles/tenant-admin-permissions/tasks/main.yml
+++ b/roles/tenant-admin-permissions/tasks/main.yml
@@ -13,10 +13,11 @@
     status_code: 201
   register: tenant_admin_login
 
-- name: "Get all permissionSets excluding okapi.*, modperms.*, and SYS#*"
-  # cql query for cql.allRecords=1 not permissionName==okapi.* not permissionName==modperms.* not permissionName==SYS#*
+- name: "Get all permissionSets excluding okapi.*, modperms.*, and SYS#*, and ui-tenant-settings.settings.locale"
+  # cql query for cql.allRecords=1 not permissionName==okapi.* not permissionName==modperms.* not permissionName==SYS#* not permissionName==ui-tenant-settings.settings.locale
+  # avoiding ui-tenant-settings.settings.locale will, hopefully, deter folks from changing the locale in the reference environments
   uri:
-    url: "{{ okapi_url }}/perms/permissions?query=cql.allRecords%3D1%20not%20permissionName%3D%3Dokapi.%2A%20not%20permissionName%3D%3Dperms.users.assign.okapi%20not%20permissionName%3D%3Dmodperms.%2A%20not%20permissionName%3D%3DSYS%23%2A&length=5000"
+    url: "{{ okapi_url }}/perms/permissions?query=cql.allRecords%3D1%20not%20permissionName%3D%3Dokapi.%2A%20not%20permissionName%3D%3Dperms.users.assign.okapi%20not%20permissionName%3D%3Dmodperms.%2A    %20not%20permissionName%3D%3DSYS%23%2A%20not permissionName==ui-tenant-settings.settings.locale&length=5000"
     method: GET
     headers:
       Accept: "application/json, text/plain"


### PR DESCRIPTION
Omit the permission `ui-tenant-settings.settings.locale` when assigning to `diku_admin` in a bid to discourage folks from altering the tenant-locale in the reference environments. This won't stop determined users from using the API to make the change, but hopefully it _will_ stop average users from using the UI to do so.