### PR TITLE
ENDPOINTS_INCLUDE_STACK_TRACE=true for other KIWT modules

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -369,6 +369,8 @@ folio_modules:
         value: "{{ aws_region | default('us-east-1') }}"
       - name: AWS_BUCKET
         value: "{{ erm_bucket_name | default('erm-bucket') }}"
+      - name: DB_MAXPOOLSIZE
+        value: "20"
       - name: ENDPOINTS_INCLUDE_STACK_TRACE
         value: "true"
 
@@ -452,6 +454,10 @@ folio_modules:
   - name: mod-oa
     deploy: yes
     docker_env:
+      - name: JAVA_OPTIONS
+        value: "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=55.0 -XX:+PrintFlagsFinal"
+      - name: DB_MAXPOOLSIZE
+        value: "20"
       - name: ENDPOINTS_INCLUDE_STACK_TRACE
         value: "true"
 
@@ -573,12 +579,18 @@ folio_modules:
   - name: mod-serials-management
     deploy: yes
     docker_env:
+      - name: JAVA_OPTIONS
+        value: "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=55.0 -XX:+PrintFlagsFinal"
+      - name: DB_MAXPOOLSIZE
+        value: "20"
       - name: ENDPOINTS_INCLUDE_STACK_TRACE
         value: "true"
 
   - name: mod-service-interaction
     deploy: yes
     docker_env:
+      - name: JAVA_OPTIONS
+        value: "-server -XX:+UseContainerSupport -XX:MaxRAMPercentage=67.0 -XX:+PrintFlagsFinal"
       - name: ENDPOINTS_INCLUDE_STACK_TRACE
         value: "true"
 

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -369,6 +369,8 @@ folio_modules:
         value: "{{ aws_region | default('us-east-1') }}"
       - name: AWS_BUCKET
         value: "{{ erm_bucket_name | default('erm-bucket') }}"
+      - name: ENDPOINTS_INCLUDE_STACK_TRACE
+        value: "true"
 
   - name: mod-lists
     deploy: yes
@@ -449,6 +451,9 @@ folio_modules:
 
   - name: mod-oa
     deploy: yes
+    docker_env:
+      - name: ENDPOINTS_INCLUDE_STACK_TRACE
+        value: "true"
 
   - name: mod-oai-pmh
     deploy: yes
@@ -567,9 +572,15 @@ folio_modules:
 
   - name: mod-serials-management
     deploy: yes
+    docker_env:
+      - name: ENDPOINTS_INCLUDE_STACK_TRACE
+        value: "true"
 
   - name: mod-service-interaction
     deploy: yes
+    docker_env:
+      - name: ENDPOINTS_INCLUDE_STACK_TRACE
+        value: "true"
 
   - name: mod-settings
     deploy: yes


### PR DESCRIPTION
mod-agreements had ENDPOINTS_INCLUDE_STACK_TRACE=true set in [this PR](https://github.com/folio-org/folio-ansible/pull/628)

This has now passed QA, so this PR brings all modules in line with this expectation that Snapshot may include stack-traces in their responses (but this will still default to `false` for live systems)