### PR TITLE
MODUSERBL-224: add EUREKA_LOGIN_PERMS env var for mod-users-bl deploy

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -641,6 +641,9 @@ folio_modules:
 
   - name: mod-users-bl
     deploy: yes
+    docker_env:
+      - name: EUREKA_LOGIN_PERMS
+        value: "false"
 
 # Variables for building UI
 stripes_github_project: https://github.com/folio-org/platform-complete

--- a/group_vars/testing
+++ b/group_vars/testing
@@ -104,6 +104,9 @@ folio_modules:
 
   - name: mod-users-bl
     deploy: yes
+    docker_env:
+      - name: EUREKA_LOGIN_PERMS
+        value: "false"
 
   - name: mod-login-saml
     deploy: yes


### PR DESCRIPTION
These changes are required to make the `mod-users-bl` module work in Okapi-based environments, considering the updates described in the related task (https://folio-org.atlassian.net/browse/MODUSERBL-224). 