### PR TITLE
Allow omitting modules from tenant enablement

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -77,6 +77,10 @@ add_modules:
 #   - module: mod-authtoken
 #     version: v2.0.0
 
+# modules to omit enabling even if they are deployed
+omit_enable:
+  - mod-circulation-bff
+
 # modules that need to be deployed
 folio_modules:
   - name: mod-agreements

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -554,6 +554,8 @@ folio_modules:
         value: "-XX:MaxRAMPercentage=66.0"
       - name: OKAPI_URL
         value: "{{ okapi_url }}"
+      - name: SYSTEM_USER_ENABLED
+        value: "false"
 
   - name: mod-rtac
     deploy: yes

--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -80,6 +80,7 @@ add_modules:
 # modules to omit enabling even if they are deployed
 omit_enable:
   - mod-circulation-bff
+  - folio_requests-mediated
 
 # modules that need to be deployed
 folio_modules:

--- a/roles/okapi-tenant-deploy/README.md
+++ b/roles/okapi-tenant-deploy/README.md
@@ -83,6 +83,7 @@ module_env:
 # Okapi setup
 folio_install_type: single_server
 folio_modules: []
+omit_enable: [] # omit these modules even if they appear in folio_modules
 okapi_port: 9130
 okapi_url: "http://{{ ansible_default_ipv4.address }}:{{ okapi_port }}"
 tenant: diku

--- a/roles/okapi-tenant-deploy/defaults/main.yml
+++ b/roles/okapi-tenant-deploy/defaults/main.yml
@@ -40,6 +40,7 @@ module_env:
 # Okapi setup
 folio_install_type: single_server
 folio_modules: []
+omit_enable: [] # omit these modules even if they appear in folio_modules
 okapi_port: 9130
 okapi_url: "http://{{ ansible_default_ipv4.address }}:{{ okapi_port }}"
 tenant: diku

--- a/roles/okapi-tenant-deploy/tasks/main.yml
+++ b/roles/okapi-tenant-deploy/tasks/main.yml
@@ -42,13 +42,13 @@
 - name: Build install list for modules with deployment
   set_fact:
     install_deploy: "{{ install_deploy|default([]) + [ install_obj|combine({'id': item.name + '-' + item.version}) ] if item.version is defined else install_deploy|default([]) + [ install_obj|combine({'id': item.name}) ] }}"
-  when: folio_install_type == "single_server" and item.url is not defined and item.deploy is defined and item.deploy is sameas true
+  when: folio_install_type == "single_server" and item.name not in omit_enable and item.url is not defined and item.deploy is defined and item.deploy is sameas true
   with_items: "{{ folio_modules }}"
 
 - name: Build install list for modules without deployment
   set_fact:
     install: "{{ install|default([]) + [ install_obj|combine({'id': item.name + '-' + item.version}) ] if item.version is defined else install|default([]) + [ install_obj|combine({'id': item.name}) ] }}"
-  when: folio_install_type == "kubernetes" or item.url is defined or item.deploy is not defined or item.deploy is sameas false
+  when: (folio_install_type == "kubernetes" or item.url is defined or item.deploy is not defined or item.deploy is sameas false) and item.name not in omit_enable
   with_items: "{{ folio_modules }}"
 
 - name: Post install list for deployment and enabling


### PR DESCRIPTION
There are times when you might want to build a system with modules that are not enabled for the tenant. This change to the `okapi-tenant-deploy` role allows you to specify modules that are included in the build but not enabled for the tenant by adding an `omit_enable` variable for that role (default to `[]`).

It allows updates the "snapshot" build to omit `mod-circulation-bff` and `folio_requests-mediated` (which are only relevant for ECS-enabled systems)