### PR TITLE
ci: Turn off Acquisition units for Agreements -- FOLIO-4516

### DIFF
--- a/group_vars/snapshot
+++ b/group_vars/snapshot
@@ -112,6 +112,8 @@ folio_modules:
         value: "20"
       - name: ENDPOINTS_INCLUDE_STACK_TRACE
         value: "true"
+      - name: ACCESSCONTROL_ACQUNITS_ENABLED
+        value: "false"
 
   - name: mod-audit
     deploy: yes


### PR DESCRIPTION
This is a test change to test whether the environment variable ACCESSCONTROL_ACQUNITS_ENABLED functions as expected in the finished build image.

Once verified, this will be reverted

refs FOLIO-4516